### PR TITLE
Added examples/*.rb and INSTALL.rdoc so they show up on rubydoc.info

### DIFF
--- a/.document
+++ b/.document
@@ -1,4 +1,7 @@
 lib/packetfu.rb
 lib/packetfu/
-README
-LICENSE
+-
+LICENSE.txt
+INSTALL.rdoc
+README.rdoc
+examples/*.rb


### PR DESCRIPTION
The examples and `INSTALL.rdoc` need to be listed on http://rubydoc.info/github/todb/packetfu/master/frames.
