### PR TITLE
Parsing speedups and spec refactor

### DIFF
--- a/lib/packetfu/packet.rb
+++ b/lib/packetfu/packet.rb
@@ -37,11 +37,11 @@ module PacketFu
 			parse_app = true if(args[:parse_app].nil? or args[:parse_app])
 			force_binary(packet)
 			if parse_app
-				classes = PacketFu.packet_classes.select {|pclass| pclass.can_parse? packet}
+				classes = PacketFu.packet_classes_by_layer
 			else
-				classes = PacketFu.packet_classes.select {|pclass| pclass.can_parse? packet}.reject {|pclass| pclass.layer_symbol == :application}
+				classes = PacketFu.packet_classes_by_layer_without_application
 			end
-			p = classes.sort {|x,y| x.layer <=> y.layer}.last.new
+			p = classes.detect { |pclass| pclass.can_parse?(packet) }.new
 			parsed_packet = p.read(packet,args)
 		end
 

--- a/spec/ethpacket_spec.rb
+++ b/spec/ethpacket_spec.rb
@@ -1,5 +1,4 @@
-$:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
-require 'packetfu'
+require 'spec_helper'
 
 include PacketFu
 

--- a/spec/packet_spec.rb
+++ b/spec/packet_spec.rb
@@ -1,11 +1,13 @@
-$:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
-require 'packetfu'
+require 'spec_helper'
 
 describe PacketFu::Packet, "abstract packet class behavior" do
 
 	before(:all) do
-		class PacketFu::FooPacket < PacketFu::Packet; end
-		class PacketFu::BarPacket < PacketFu::Packet; end
+		add_fake_packets
+	end
+
+	after(:all) do
+		remove_fake_packets
 	end
 
 	it "should not be instantiated" do

--- a/spec/packet_subclasses_spec.rb
+++ b/spec/packet_subclasses_spec.rb
@@ -1,5 +1,4 @@
-$:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
-require 'packetfu'
+require 'spec_helper'
 
 PacketFu.packet_classes.each do |pclass|
 	describe pclass, "peek format" do

--- a/spec/packetfu_spec.rb
+++ b/spec/packetfu_spec.rb
@@ -1,5 +1,4 @@
-$:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
-require 'packetfu'
+require 'spec_helper'
 
 describe PacketFu, "version information" do
 	it "reports a version number" do
@@ -55,12 +54,6 @@ describe PacketFu, "protocol requires" do
 end
 
 describe PacketFu, "packet class list management" do
-
-	before(:all) do
-		class PacketFu::FooPacket < PacketFu::Packet; end
-		class PacketFu::BarPacket < PacketFu::Packet; end
-		class PacketFu::PacketBaz; end
-	end
 
 	it "should allow packet class registration" do
 		PacketFu.add_packet_class(PacketFu::FooPacket).should be_kind_of Array

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,31 @@
+$:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
+require 'packetfu'
+
+module FakePacket
+	def layer
+		7
+	end
+end
+
+class PacketFu::FooPacket < PacketFu::Packet
+	extend FakePacket
+end
+
+class PacketFu::BarPacket < PacketFu::Packet
+	extend FakePacket
+end
+
+class PacketBaz
+end
+
+def add_fake_packets
+	PacketFu.add_packet_class(PacketFu::FooPacket)
+	PacketFu.add_packet_class(PacketFu::BarPacket)
+end
+
+def remove_fake_packets
+	PacketFu.remove_packet_class(PacketFu::FooPacket)
+	PacketFu.remove_packet_class(PacketFu::BarPacket)
+end
+
+remove_fake_packets

--- a/spec/structfu_spec.rb
+++ b/spec/structfu_spec.rb
@@ -1,5 +1,4 @@
-$:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
-require 'packetfu'
+require 'spec_helper'
 
 describe StructFu, "mixin methods" do
 

--- a/spec/tcp_spec.rb
+++ b/spec/tcp_spec.rb
@@ -1,5 +1,4 @@
-$:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
-require 'packetfu'
+require 'spec_helper'
 
 include PacketFu
 


### PR DESCRIPTION
When parsing a packet - it would seem more then the minimum amount of checks are made - for example, if a packet is a TCP packet then we need not check if a packet is an Ethernet or IP packet specifically because the fact that it is a TCP packet will result in TCP being chosen due to the higher "layer" level. So, why not sort the classes in descending layer order and then take the first class that #can_parse? the packet?

This change accomplishes just that.

It also refactors up the specs just slightly in order to not have the "fake packets" become issues now that the system checks their layer without the classes being used for parsing.

Hope I did not go too far or step on any toes.......
