### PR TITLE
Better dependencies and add bundler compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in packetfu.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,33 @@
+PATH
+  remote: .
+  specs:
+    packetfu (1.1.9)
+      pcaprub (>= 0.9.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.4)
+    json (1.8.0)
+    pcaprub (0.11.3)
+    rdoc (3.12.2)
+      json (~> 1.4)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.6)
+    rspec-expectations (2.14.3)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.4)
+    sdoc (0.3.20)
+      json (>= 1.1.3)
+      rdoc (~> 3.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  packetfu!
+  rspec (>= 2.6.2)
+  sdoc (>= 0.2.0)

--- a/packetfu.gemspec
+++ b/packetfu.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split($/)
   s.license     = 'BSD'
 
-  s.add_development_dependency('pcaprub', '>= 0.9.2')
+  s.add_dependency('pcaprub', '>= 0.9.2')
   s.add_development_dependency('rspec',   '>= 2.6.2')
   s.add_development_dependency('sdoc',    '>= 0.2.0')
 


### PR DESCRIPTION
Hi,

While using your gem in a Gemfile, I had an error because rubpcap was missing, but the error was not really easy to understand.

I improved the dependencies in your gemspec so when using bundle, rubpcap gets installed as a dependency.

Also, I added a Gemfile and Gemfile.lock to be sure everyone that works on this gem uses the same version of rubpcap, rspec, etc.

Cheers
