### PR TITLE
Add better default int support to #whoami? via network_interface gem

### DIFF
--- a/packetfu.gemspec
+++ b/packetfu.gemspec
@@ -11,6 +11,8 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split($/)
   s.license     = 'BSD'
 
+  s.add_dependency('network_interface', '>= 0.0.1')
+
   s.add_development_dependency('pcaprub', '>= 0.9.2')
   s.add_development_dependency('rspec',   '>= 2.6.2')
   s.add_development_dependency('sdoc',    '>= 0.2.0')


### PR DESCRIPTION
This MR picks up where we left off on PR #42

1.) Adds network_interface dependency to gemset specification
2.) Adds #default_ip, #rand_port and #default_int helper methods
3.) Fixes #whoami? bug when no parameters are specified the default interface is not returned when it's not the first in the interface list (common problem for Laptop users testing over wireless)
