### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - 1.9.3


### PR DESCRIPTION
Getting us moving the right direction for moving towards real CI.

I decided to just do Ruby 1.9.3 HEAD for now until we get around to making PackeFu 2.0/2.1 compatible.

With the current Rakefile, this will just get us RSpec runs.  If we want to add the ./tests stuff, we'll want to add a script extension to this and invoke them with sudo rights.

I figured that Rspec would be a decent first start for now, especially since that's the direction we want to be headed.

Relates to #45 
