### PR TITLE
Update pcap.rb

### DIFF
--- a/lib/packetfu/pcap.rb
+++ b/lib/packetfu/pcap.rb
@@ -422,7 +422,7 @@ module PacketFu
       end
       arr.each_with_index do |p,i|
         if p.kind_of? Hash # Binary timestamps are included
-          this_ts = p.keys.first
+          this_ts = p.keys.first.dup
           this_incl_len = p.values.first.size
           this_orig_len = this_incl_len
           this_data = p.values.first


### PR DESCRIPTION
Fixes problem with crash when attempting to change encoding on frozen string from hash key

As written PCapFile.array_to_file will attempt to use the key part of a Hash as a binary timestamp value if the array elements passed through the method's :array/:arr/:a parameter are hashes instead of Packets. Hash keys are "frozen" in ruby 2, so an attempt to force binary encoded on a frozen string fails.

"dup"ing the hash key before attempting to force encoding solves this.