### PR TITLE
Fixed PacketFu::Utils.ifconfig under OS X

### DIFF
--- a/lib/packetfu/utils.rb
+++ b/lib/packetfu/utils.rb
@@ -27,9 +27,9 @@ module PacketFu
     #  === Example
     #    PacketFu::Utils::arp("192.168.1.1") #=> "00:18:39:01:33:70"
     #    PacketFu::Utils::arp("192.168.1.1", :iface => "wlan2", :timeout => 5, :flavor => :hp_deskjet)
-    #  
+    #
     #  === Warning
-    #  
+    #
     #  It goes without saying, spewing forged ARP packets on your network is a great way to really
     #  irritate your co-workers.
     def self.arp(target_ip,args={})
@@ -42,7 +42,7 @@ module PacketFu
       # Stick the Capture object in its own thread.
       cap_thread = Thread.new do
         target_mac = nil
-        cap = PacketFu::Capture.new(:iface => iface, :start => true, 
+        cap = PacketFu::Capture.new(:iface => iface, :start => true,
         :filter => "arp src #{target_ip} and ether dst #{arp_pkt.eth_saddr}")
         arp_pkt.to_w(iface) # Shorthand for sending single packets to the default interface.
         timeout = 0
@@ -59,7 +59,7 @@ module PacketFu
       cap_thread.value
     end
 
-    # Since 177/8 is IANA reserved (for now), this network should 
+    # Since 177/8 is IANA reserved (for now), this network should
     # be handled by your default gateway and default interface.
     def self.rand_routable_daddr
       IPAddr.new((rand(16777216) + 2969567232), Socket::AF_INET)
@@ -75,14 +75,14 @@ module PacketFu
     # operation; a UDP packet is generated and dropped on to the default (or named)
     # interface, and then captured (which means you need to be root to do this).
     #
-    # whoami? returns a hash of :eth_saddr, :eth_src, :ip_saddr, :ip_src, 
-    # :ip_src_bin, :eth_dst, and :eth_daddr (the last two are usually suitable 
-    # for a gateway mac address). It's most useful as an argument to 
+    # whoami? returns a hash of :eth_saddr, :eth_src, :ip_saddr, :ip_src,
+    # :ip_src_bin, :eth_dst, and :eth_daddr (the last two are usually suitable
+    # for a gateway mac address). It's most useful as an argument to
     # PacketFu::Config.new, or as an argument to the many Packet constructors.
     #
     # Note that if you have multiple interfaces with the same route (such as when
     # wlan0 and eth0 are associated to the same network), the "first" one
-    # according to Pcap.lookupdev will be used, regardless of which :iface you 
+    # according to Pcap.lookupdev will be used, regardless of which :iface you
     # pick.
     #
     # === Parameters
@@ -114,13 +114,13 @@ module PacketFu
       begin
         Timeout::timeout(1) {
           pkt = nil
-          
+
           while pkt.nil?
             raw_pkt = cap.next
             next if raw_pkt.nil?
 
             pkt = Packet.parse(raw_pkt)
-            
+
             if pkt.payload == msg
 
               my_data =	{
@@ -135,7 +135,7 @@ module PacketFu
                 :eth_daddr => pkt.eth_daddr
               }
 
-            else raise SecurityError, 
+            else raise SecurityError,
               "whoami() packet doesn't match sent data. Something fishy's going on."
             end
 
@@ -152,7 +152,7 @@ module PacketFu
     def self.default_ip
       begin
         orig, Socket.do_not_reverse_lookup = Socket.do_not_reverse_lookup, true  # turn off reverse DNS resolution temporarily
- 
+
   			UDPSocket.open do |s|
     			s.connect rand_routable_daddr.to_s, rand_port
     			s.addr.last
@@ -182,8 +182,8 @@ module PacketFu
     # Handles ifconfig for various (okay, two) platforms.
     # Will have Windows done shortly.
     #
-    # Takes an argument (either string or symbol) of the interface to look up, and 
-    # returns a hash which contains at least the :iface element, and if configured, 
+    # Takes an argument (either string or symbol) of the interface to look up, and
+    # returns a hash which contains at least the :iface element, and if configured,
     # these additional elements:
     #
     #   :eth_saddr  # A human readable MAC address
@@ -198,7 +198,7 @@ module PacketFu
     #   PacketFu::Utils.ifconfig :wlan0 # Not associated yet
     #   #=> {:eth_saddr=>"00:1d:e0:73:9d:ff", :eth_src=>"\000\035\340s\235\377", :iface=>"wlan0"}
     #   PacketFu::Utils.ifconfig("eth0") # Takes 'eth0' as default
-    #   #=> {:eth_saddr=>"00:1c:23:35:70:3b", :eth_src=>"\000\034#5p;", :ip_saddr=>"10.10.10.9", :ip4_obj=>#<IPAddr: IPv4:10.10.10.0/255.255.254.0>, :ip_src=>"\n\n\n\t", :iface=>"eth0", :ip6_saddr=>"fe80::21c:23ff:fe35:703b/64", :ip6_obj=>#<IPAddr: IPv6:fe80:0000:0000:0000:0000:0000:0000:0000/ffff:ffff:ffff:ffff:0000:0000:0000:0000>}  
+    #   #=> {:eth_saddr=>"00:1c:23:35:70:3b", :eth_src=>"\000\034#5p;", :ip_saddr=>"10.10.10.9", :ip4_obj=>#<IPAddr: IPv4:10.10.10.0/255.255.254.0>, :ip_src=>"\n\n\n\t", :iface=>"eth0", :ip6_saddr=>"fe80::21c:23ff:fe35:703b/64", :ip6_obj=>#<IPAddr: IPv6:fe80:0000:0000:0000:0000:0000:0000:0000/ffff:ffff:ffff:ffff:0000:0000:0000:0000>}
     #   PacketFu::Utils.ifconfig :lo
     #   #=> {:ip_saddr=>"127.0.0.1", :ip4_obj=>#<IPAddr: IPv4:127.0.0.0/255.0.0.0>, :ip_src=>"\177\000\000\001", :iface=>"lo", :ip6_saddr=>"::1/128", :ip6_obj=>#<IPAddr: IPv6:0000:0000:0000:0000:0000:0000:0000:0001/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff>}
     def self.ifconfig(iface='eth0')
@@ -244,11 +244,16 @@ module PacketFu
           when /ether[\s]([0-9a-fA-F:]{17})/i
             ret[:eth_saddr] = $1
             ret[:eth_src] = EthHeader.mac2str(ret[:eth_saddr])
-          when /inet[\s]*([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(.*Mask:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+))?/i
+          when /inet[\s]*([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(.*Mask[\s]+(0x[a-f0-9]+))?/i
+            imask = 0
+            if $3
+              imask = $3.to_i(16).to_s(2).count("1")
+            end
+
             ret[:ip_saddr] = $1
             ret[:ip_src] = [IPAddr.new($1).to_i].pack("N")
             ret[:ip4_obj] = IPAddr.new($1)
-            ret[:ip4_obj] = ret[:ip4_obj].mask($3) if $3
+            ret[:ip4_obj] = ret[:ip4_obj].mask(imask) if imask
           when /inet6[\s]*([0-9a-fA-F:\x2f]+)/
             ret[:ip6_saddr] = $1
             ret[:ip6_obj] = IPAddr.new($1)


### PR DESCRIPTION
PacketFu::Utils.ifconfig is broken under OS X, it does not correctly parse the netmask field due to a wrong regular expression.