### PR TITLE
Add iface validation to PacketFu::Utils.ifconfig

### DIFF
--- a/lib/packetfu/utils.rb
+++ b/lib/packetfu/utils.rb
@@ -202,6 +202,10 @@ module PacketFu
     #   PacketFu::Utils.ifconfig :lo
     #   #=> {:ip_saddr=>"127.0.0.1", :ip4_obj=>#<IPAddr: IPv4:127.0.0.0/255.0.0.0>, :ip_src=>"\177\000\000\001", :iface=>"lo", :ip6_saddr=>"::1/128", :ip6_obj=>#<IPAddr: IPv6:0000:0000:0000:0000:0000:0000:0000:0001/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff>}
     def self.ifconfig(iface=default_int)
+      unless NetworkInterface.interfaces.include?(iface)
+        raise ArgumentError, "#{iface} interface does not exist"
+      end
+
       ret = {}
       iface = iface.to_s.scan(/[0-9A-Za-z]/).join # Sanitizing input, no spaces, semicolons, etc.
       case RUBY_PLATFORM

--- a/lib/packetfu/utils.rb
+++ b/lib/packetfu/utils.rb
@@ -246,8 +246,7 @@ module PacketFu
         else
           raise ArgumentError, "Cannot ifconfig #{iface}"
         end
-        real_iface = ifconfig_data.first
-        ret[:iface] = real_iface.split(':')[0]
+        ret[:iface] = iface
         ifconfig_data.each do |s|
           case s
           when /ether[\s]([0-9a-fA-F:]{17})/i

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+include PacketFu
+
+describe Utils do
+  context "when using ifconfig" do
+    it "should return a hash" do
+      PacketFu::Utils.ifconfig().should be_a(::Hash)
+    end
+
+    it "should prevent non-interface values" do
+      expect {
+        PacketFu::Utils.ifconfig("not_a_interface")
+      }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -24,6 +24,9 @@ describe Utils do
       allow(PacketFu::Utils).to receive(:ifconfig_data_string) { mac_osx_reply }
       util_reply = PacketFu::Utils.ifconfig
 
+      # Ensure we got a hash back
+      expect(util_reply).to be_a(::Hash)
+
       # Ensure all our values parse correctly
       expect(util_reply[:iface]).to eq("ifconfig en0")
       expect(util_reply[:eth_saddr]).to eq("78:31:c1:ce:39:bc")

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -4,10 +4,6 @@ include PacketFu
 
 describe Utils do
   context "when using ifconfig" do
-    it "should return a hash" do
-      PacketFu::Utils.ifconfig().should be_a(::Hash)
-    end
-
     it "should prevent non-interface values" do
       expect {
         PacketFu::Utils.ifconfig("not_an_interface")

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -10,7 +10,7 @@ describe Utils do
 
     it "should prevent non-interface values" do
       expect {
-        PacketFu::Utils.ifconfig("not_a_interface")
+        PacketFu::Utils.ifconfig("not_an_interface")
       }.to raise_error(ArgumentError)
     end
   end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -29,7 +29,7 @@ describe Utils do
       expect(util_reply).to be_a(::Hash)
 
       # Ensure all our values parse correctly
-      expect(util_reply[:iface]).to eq("ifconfig en0")
+      expect(util_reply[:iface]).to eq("en0")
       expect(util_reply[:eth_saddr]).to eq("78:31:c1:ce:39:bc")
       expect(util_reply[:eth_src]).to eq("x1\xC1\xCE9\xBC")
       expect(util_reply[:ip6_saddr]).to eq("fe80::7a31:c1ff:fece:39bc")

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -21,8 +21,8 @@ describe Utils do
                       "nd6 options=1<PERFORMNUD>\n" +
                       "media: autoselect\n" +
                       "status: active\n"
-      allow(PacketFu::Utils).to receive(:ifconfig_data_string) { mac_osx_reply }
-      util_reply = PacketFu::Utils.ifconfig
+      allow(PacketFu::Utils).to receive(:ifconfig_data_string).and_return(mac_osx_reply)
+      util_reply = PacketFu::Utils.ifconfig("en0")
 
       # Ensure we got a hash back
       expect(util_reply).to be_a(::Hash)

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -7,7 +7,7 @@ describe Utils do
     it "should prevent non-interface values" do
       expect {
         PacketFu::Utils.ifconfig("not_an_interface")
-      }.to raise_error(ArgumentError)
+      }.to raise_error(ArgumentError, /interface does not exist$/)
     end
   end
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -13,6 +13,7 @@ describe Utils do
     end
 
     it "should work on Mac OSX Yosemite" do
+      stub_const("RUBY_PLATFORM", "x86_64-darwin14")
       mac_osx_reply = "ifconfig en0\n" + 
                       "en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500\n" +
                       "ether 78:31:c1:ce:39:bc\n" +
@@ -37,5 +38,33 @@ describe Utils do
       expect(util_reply[:ip_src]).to eq("\xC0\xA8\n\xAD")
       expect(util_reply[:ip4_obj]).to eq(IPAddr.new("192.168.10.0/24"))
     end
+
+    it "should work on Ubuntu 14.04 LTS" do
+      stub_const("RUBY_PLATFORM", "x86_64-linux")
+      ubuntu_reply = "eth0      Link encap:Ethernet  HWaddr 00:0c:29:2a:e3:bd\n" + 
+                     "inet addr:192.168.10.174  Bcast:192.168.10.255  Mask:255.255.255.0\n" + 
+                     "inet6 addr: fe80::20c:29ff:fe2a:e3bd/64 Scope:Link\n" + 
+                     "UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1\n" + 
+                     "RX packets:65782 errors:0 dropped:0 overruns:0 frame:0\n" + 
+                     "TX packets:31354 errors:0 dropped:0 overruns:0 carrier:0\n" + 
+                     "collisions:0 txqueuelen:1000\n" + 
+                     "RX bytes:40583515 (40.5 MB)  TX bytes:3349554 (3.3 MB)"
+      allow(PacketFu::Utils).to receive(:ifconfig_data_string).and_return(ubuntu_reply)
+      util_reply = PacketFu::Utils.ifconfig("eth0")
+
+      # Ensure we got a hash back
+      expect(util_reply).to be_a(::Hash)
+
+      # Ensure all our values parse correctly
+      expect(util_reply[:iface]).to eq("eth0")
+      expect(util_reply[:eth_saddr]).to eq("00:0c:29:2a:e3:bd")
+      expect(util_reply[:eth_src]).to eq("\x00\f)*\xE3\xBD")
+      expect(util_reply[:ip6_saddr]).to eq("fe80::20c:29ff:fe2a:e3bd/64")
+      expect(util_reply[:ip6_obj]).to eq(IPAddr.new("fe80::20c:29ff:fe2a:e3bd/64"))
+      expect(util_reply[:ip_saddr]).to eq("192.168.10.174")
+      expect(util_reply[:ip_src]).to eq("\xC0\xA8\n\xAE")
+      expect(util_reply[:ip4_obj]).to eq(IPAddr.new("192.168.10.0/24"))
+    end
+
   end
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 require 'spec_helper'
 
 include PacketFu
@@ -8,6 +10,29 @@ describe Utils do
       expect {
         PacketFu::Utils.ifconfig("not_an_interface")
       }.to raise_error(ArgumentError, /interface does not exist$/)
+    end
+
+    it "should work on Mac OSX Yosemite" do
+      mac_osx_reply = "ifconfig en0\n" + 
+                      "en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500\n" +
+                      "ether 78:31:c1:ce:39:bc\n" +
+                      "inet6 fe80::7a31:c1ff:fece:39bc%en0 prefixlen 64 scopeid 0x4\n" +
+                      "inet 192.168.10.173 netmask 0xffffff00 broadcast 192.168.10.255\n" +
+                      "nd6 options=1<PERFORMNUD>\n" +
+                      "media: autoselect\n" +
+                      "status: active\n"
+      allow(PacketFu::Utils).to receive(:ifconfig_data_string) { mac_osx_reply }
+      util_reply = PacketFu::Utils.ifconfig
+
+      # Ensure all our values parse correctly
+      expect(util_reply[:iface]).to eq("ifconfig en0")
+      expect(util_reply[:eth_saddr]).to eq("78:31:c1:ce:39:bc")
+      expect(util_reply[:eth_src]).to eq("x1\xC1\xCE9\xBC")
+      expect(util_reply[:ip6_saddr]).to eq("fe80::7a31:c1ff:fece:39bc")
+      expect(util_reply[:ip6_obj]).to eq(IPAddr.new("fe80::7a31:c1ff:fece:39bc"))
+      expect(util_reply[:ip_saddr]).to eq("192.168.10.173")
+      expect(util_reply[:ip_src]).to eq("\xC0\xA8\n\xAD")
+      expect(util_reply[:ip4_obj]).to eq(IPAddr.new("192.168.10.0/24"))
     end
   end
 end


### PR DESCRIPTION
So, yeah, found a minor security bug that would allow a user-defined iface value to result in command execution.

This change allows us to be a little more strict about what iface values we'll simply eval, by restricting it to only valid interfaces on the system.

This also adds specs for PacketFu::Utils.ifconfig, including OS specific examples, and fixes another minor Mac OSX parsing bug.