### PR TITLE
Fix packetfu gem build warnings

### DIFF
--- a/packetfu.gemspec
+++ b/packetfu.gemspec
@@ -12,13 +12,12 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split($/)
   s.license     = 'BSD'
 
-  s.add_dependency('network_interface', '>= 0.0.1')
-  s.add_dependency('pcaprub', '>= 0.9.2')
-  s.add_development_dependency('bundler')
-  s.add_development_dependency('rake')
-  s.add_development_dependency('rspec',     '>= 2.14.1')
-  s.add_development_dependency('rspec-its', '>= 1.0.0')
-  s.add_development_dependency('sdoc',      '>= 0.2.0')
+  s.add_dependency('network_interface', '~> 0.0')
+  s.add_dependency('pcaprub', '~> 0.12')
+  s.add_development_dependency('rake', '~> 10.3')
+  s.add_development_dependency('rspec', '~> 3.0')
+  s.add_development_dependency('rspec-its', '~> 1.2')
+  s.add_development_dependency('sdoc', '~> 0.4.1')
 
   s.extra_rdoc_files  = %w[.document README.rdoc]
   s.test_files        = (s.files & (Dir['spec/**/*_spec.rb'] + Dir['test/test_*.rb']) )


### PR DESCRIPTION
In the interest in getting us ready to build/release a new gem, I have tuned up the .gemspec so that it will build without semantic version warnings.