### PR TITLE
Fix specs for Ruby 2.2.2 compatibility

### DIFF
--- a/test/test_arp.rb
+++ b/test/test_arp.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# -*- coding: binary -*-
+
 require 'test/unit'
 $:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
 require 'packetfu'

--- a/test/test_capture.rb
+++ b/test/test_capture.rb
@@ -11,7 +11,7 @@ class CaptureTest < Test::Unit::TestCase
   end
 
   def test_whoami
-    assert_nothing_raised { PacketFu::Utils.whoami?(:iface => (ENV['IFACE'] || 'lo')) }
+    assert_nothing_raised { PacketFu::Utils.whoami?(:iface => PacketFu::Utils.default_int) }
   end
   
   def test_new

--- a/test/test_eth.rb
+++ b/test/test_eth.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# -*- coding: binary -*-
+
 require 'test/unit'
 $:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
 require 'packetfu'

--- a/test/test_icmp.rb
+++ b/test/test_icmp.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# -*- coding: binary -*-
+
 require 'test/unit'
 $:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
 require 'packetfu'

--- a/test/test_inject.rb
+++ b/test/test_inject.rb
@@ -11,12 +11,12 @@ class InjectTest < Test::Unit::TestCase
   end
 
   def test_whoami
-    assert_nothing_raised { PacketFu::Utils.whoami?(:iface => (ENV['IFACE'] || 'lo')) }
+    assert_nothing_raised { PacketFu::Utils.whoami?(:iface => PacketFu::Utils.default_int) }
   end
 
   def test_to_w
     assert_equal(Process.euid, 0, "TEST FAIL: This test must be run as root")
-    conf = PacketFu::Utils.whoami?(:iface => (ENV['IFACE'] || 'lo'))
+    conf = PacketFu::Utils.whoami?(:iface => PacketFu::Utils.default_int)
     p = PacketFu::UDPPacket.new(:config => conf)
     p.udp_dport = 12345
     p.udp_sport = 12345

--- a/test/test_ip.rb
+++ b/test/test_ip.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# -*- coding: binary -*-
+
 require 'test/unit'
 $:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
 require 'packetfu'

--- a/test/test_ip6.rb
+++ b/test/test_ip6.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# -*- coding: binary -*-
+
 require 'test/unit'
 $:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
 require 'packetfu'

--- a/test/test_octets.rb
+++ b/test/test_octets.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# -*- coding: binary -*-
+
 require 'test/unit'
 $:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
 require 'packetfu'

--- a/test/test_packet.rb
+++ b/test/test_packet.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# -*- coding: binary -*-
+
 require 'test/unit'
 $:.unshift File.expand_path(File.join(File.dirname(__FILE__), "..", "lib"))
 require 'packetfu'

--- a/test/test_pcap.rb
+++ b/test/test_pcap.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# -*- coding: binary -*-
+
 require 'test/unit'
 $:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
 require 'packetfu'

--- a/test/test_structfu.rb
+++ b/test/test_structfu.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# -*- coding: binary -*-
+
 require 'test/unit'
 $:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
 require 'packetfu'

--- a/test/test_tcp.rb
+++ b/test/test_tcp.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# -*- coding: binary -*-
+
 require 'test/unit'
 $:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
 require 'packetfu'

--- a/test/test_udp.rb
+++ b/test/test_udp.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# -*- coding: binary -*-
+
 require 'test/unit'
 $:.unshift File.join(File.expand_path(File.dirname(__FILE__)), "..", "lib")
 require 'packetfu'


### PR DESCRIPTION
Rspec:

    Finished in 0.30504 seconds (files took 0.29478 seconds to load)
    214 examples, 0 failures

Testcase (only one failure on OSX - haven't figured out the source of that one yet, but other stuff works):

    ..F
    ===============================================================================
    Failure: <false> is not true.
    test_filter(CaptureTest)
    test_capture.rb:32:in `test_filter'
         29:     %x{ping -c 1 #{daddr}}
         30:     sleep 1
         31:     cap.save
      => 32:     assert cap.array.size == 1
         33:     pkt = PacketFu::Packet.parse(cap.array.first)
         34:     assert pkt.ip_daddr == daddr
         35:   end
    ===============================================================================
    ...

    Finished in 25.336827 seconds.

    6 tests, 6 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    83.3333% passed