### PR TITLE
Fix raise_error rspec warnings

### DIFF
--- a/spec/packet_spec.rb
+++ b/spec/packet_spec.rb
@@ -28,7 +28,7 @@ describe PacketFu::Packet, "abstract packet class behavior" do
     expect {
       class PacketFu::PacketNot < PacketFu::Packet
       end
-    }.to raise_error
+    }.to raise_error(RuntimeError, "Packet classes should be named 'ProtoPacket'")
     PacketFu.packet_classes.include?(PacketFu::PacketNot).should be false
     PacketFu.packet_classes {should_not include(PacketNot) }
   end

--- a/spec/packetfu_spec.rb
+++ b/spec/packetfu_spec.rb
@@ -49,7 +49,7 @@ describe PacketFu, "protocol requires" do
     PacketFu::EthPacket.should_not be_nil
     PacketFu::IPPacket.should_not be_nil
     PacketFu::TCPPacket.should_not be_nil
-    expect { PacketFu::FakePacket }.to raise_error
+    expect { PacketFu::FakePacket }.to raise_error(NameError, "uninitialized constant PacketFu::FakePacket")
   end
 end
 
@@ -63,7 +63,7 @@ describe PacketFu, "packet class list management" do
   its(:packet_classes) {should include(PacketFu::FooPacket)}
 
   it "should disallow non-classes as packet classes" do
-    expect { PacketFu.add_packet_class("A String") }.to raise_error
+    expect { PacketFu.add_packet_class("A String") }.to raise_error(RuntimeError, "Need a class")
   end
 
   its(:packet_prefixes) {should include("bar")}

--- a/spec/structfu_spec.rb
+++ b/spec/structfu_spec.rb
@@ -32,7 +32,7 @@ describe StructFu::Int, "basic Int class" do
   end
 
   it "should raise when to_s'ed directly" do
-    expect { @int.to_s}.to raise_error
+    expect { @int.to_s}.to raise_error(StandardError, "StructFu::Int#to_s accessed, must be redefined.")
   end
 
   it "should have a value of 8" do
@@ -145,8 +145,8 @@ describe StructFu::Int16le, "2 byte little-endian value" do
   end
 
   it "should raise when you try to change endianness" do
-    expect { @int.endian = :big }.to raise_error
-    expect { @int.endian = :little }.to raise_error
+    expect { @int.endian = :big }.to raise_error(NoMethodError, /undefined method `endian='/)
+    expect { @int.endian = :little }.to raise_error(NoMethodError, /undefined method `endian='/)
   end
 
 end
@@ -162,8 +162,8 @@ describe StructFu::Int16be, "2 byte big-endian value" do
   end
 
   it "should raise when you try to change endianness" do
-    expect { @int.endian = :big }.to raise_error
-    expect { @int.endian = :little }.to raise_error
+    expect { @int.endian = :big }.to raise_error(NoMethodError, /undefined method `endian='/)
+    expect { @int.endian = :little }.to raise_error(NoMethodError, /undefined method `endian='/)
   end
 
 end
@@ -230,8 +230,8 @@ describe StructFu::Int32le, "4 byte little-endian value" do
   end
 
   it "should raise when you try to change endianness" do
-    expect { @int.endian = :big }.to raise_error
-    expect { @int.endian = :little }.to raise_error
+    expect { @int.endian = :big }.to raise_error(NoMethodError, /undefined method `endian='/)
+    expect { @int.endian = :little }.to raise_error(NoMethodError, /undefined method `endian='/)
   end
 
 end
@@ -247,8 +247,8 @@ describe StructFu::Int32be, "4 byte big-endian value" do
   end
 
   it "should raise when you try to change endianness" do
-    expect { @int.endian = :big }.to raise_error
-    expect { @int.endian = :little }.to raise_error
+    expect { @int.endian = :big }.to raise_error(NoMethodError, /undefined method `endian='/)
+    expect { @int.endian = :little }.to raise_error(NoMethodError, /undefined method `endian='/)
   end
 
 end
@@ -328,7 +328,7 @@ describe StructFu::IntString do
 
   it "should raise when a string is too short" do
     data = "\x01A"
-    expect { @istr.read(data) }.to raise_error
+    expect { @istr.read(data) }.to raise_error(StandardError, "String is too short for type StructFu::Int32")
   end
 
 end


### PR DESCRIPTION
I happened to notice these warnings in the other PR I sent there were a bunch of rspec warnings for raise_error rspec syntax without explicit expectations.  This new expectation is to avoid cases where you expect something to throw an exception for a specific item and rspec could be tricked into matching on something silly like a NoMethod instead, so the goal is to be more explicit.