### PR TITLE
Add pry as a dev dep

### DIFF
--- a/packetfu.gemspec
+++ b/packetfu.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('rspec-its', '~> 1.2')
   s.add_development_dependency('sdoc', '~> 0.4.1')
+  s.add_development_dependency('pry')
 
   s.extra_rdoc_files  = %w[.document README.rdoc]
   s.test_files        = (s.files & (Dir['spec/**/*_spec.rb'] + Dir['test/test_*.rb']) )


### PR DESCRIPTION
As I'm working through the rspec conversions I keep finding myself debugging certain object classes to learn about them.  I also generally prefer pry for debugging and it's a bit annoying to have to keep adding/removing it manually from the gemspec.

I'm proposing this purely for my own ease of use when debugging.  I welcome feedback if that's not preferred.