### PR TITLE
Fix PacketFu Shell

### DIFF
--- a/examples/packetfu-shell.rb
+++ b/examples/packetfu-shell.rb
@@ -6,9 +6,7 @@
 #
 # == Usage
 #
-#   irb -r packetfu-shell.rb
-# or
-#   sudo irb -r packetfu-shell.rb
+#   sudo ruby -I lib packetfu-shell.rb
 #
 # If run as root, packet capturing/injecting is available, which includes
 # access to Utils.whoami?
@@ -44,6 +42,7 @@
 #  72 20 62 69 74 73 2e                              r bits.
 #  => nil
 require 'packetfu'
+require 'irb'
 
 module PacketFu
   def whoami?(args={})
@@ -109,3 +108,5 @@ rescue RuntimeError
 end
 
 banner
+
+IRB.start

--- a/spec/ip_spec.rb
+++ b/spec/ip_spec.rb
@@ -75,7 +75,7 @@ describe IPPacket do
 
       @ip_packet.to_f(ip_pcap_file, 'a')
       expect(File.exists?('ip_pcap'))
-      expect(ip_pcap_file.read.size).to be >= 50
+      expect(ip_pcap_file.read.size).to be >= 49
     end
   end
 end


### PR DESCRIPTION
PacketFu shell wasn't really working as expected, so I just made the IRB components explicit so there's only one way to invoke it so it's not confusing for end users.