### PR TITLE
Fix test for ruby2.3

### DIFF
--- a/spec/packetfu_spec.rb
+++ b/spec/packetfu_spec.rb
@@ -54,7 +54,7 @@ describe PacketFu, "protocol requires" do
     PacketFu::EthPacket.should_not be_nil
     PacketFu::IPPacket.should_not be_nil
     PacketFu::TCPPacket.should_not be_nil
-    expect { PacketFu::FakePacket }.to raise_error(NameError, "uninitialized constant PacketFu::FakePacket")
+    expect { PacketFu::FakePacket }.to raise_error(NameError, /uninitialized constant PacketFu::FakePacket/)
   end
 end
 


### PR DESCRIPTION
For some reason this test fails for me in migration to ruby2.3:

```
RUBYLIB=/<<PKGBUILDDIR>>/debian/ruby-packetfu/usr/lib/ruby/vendor_ruby:. GEM_PATH=debian/ruby-packetfu/usr/share/rubygems-integration/all:/var/lib/gems/2.3.0:/usr/lib/x86_64-linux-gnu/rubygems-integration/2.3.0:/usr/share/rubygems-integration/2.3.0:/usr/share/rubygems-integration/all ruby2.3 debian/ruby-tests.rb
/usr/bin/ruby2.3 -rrspec/its /usr/bin/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
rspec 3.3.2
.......................................................................F................................................................................................................................................................................

Failures:

  1) PacketFu protocol requires should have some protocols defined
     Failure/Error: expect { PacketFu::FakePacket }.to raise_error(NameError, 'uninitialized constant PacketFu::FakePacket')
       expected NameError with "uninitialized constant PacketFu::FakePacket", got #<NameError: uninitialized constant PacketFu::FakePacket
       Did you mean?  FakePacket> with backtrace:
         # ./spec/packetfu_spec.rb:52:in `block (3 levels) in <top (required)>'
         # ./spec/packetfu_spec.rb:52:in `block (2 levels) in <top (required)>'
     # ./spec/packetfu_spec.rb:52:in `block (2 levels) in <top (required)>'

Finished in 0.24044 seconds (files took 0.18794 seconds to load)
248 examples, 1 failure
```
The solution that I found was substitute quotation mark to slash, which will maintain the test behave and the test pass.