### PR TITLE
Temporarily suspend Travis-CI builds for 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 before_install:
  - sudo apt-get install libpcap-dev -qq
 rvm:
-  - 1.9.3
+  #- 1.9.3
   - 2.0.0
   - 2.1.6
   - 2.2.3


### PR DESCRIPTION
Travis is dealing with a bundler bug that may require us to suspect 1.9.3 builds (which are EOL as of Feb this year) to fix until they put out another release.