### PR TITLE
Add coveralls badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/*test.pcap
 Gemfile.lock
 .ruby-gemset*
 .ruby-version*
+coverage

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://secure.travis-ci.org/packetfu/packetfu.png)](http://travis-ci.org/packetfu/packetfu)
 [![Code Climate](https://codeclimate.com/github/packetfu/packetfu.png)](https://codeclimate.com/github/packetfu/packetfu)
+[![Coverage Status](https://coveralls.io/repos/github/packetfu/packetfu/badge.svg?branch=master)](https://coveralls.io/github/packetfu/packetfu?branch=master)
 
 A library for reading and writing packets to an interface or to a
 libpcap-formatted file.

--- a/packetfu.gemspec
+++ b/packetfu.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec-its', '~> 1.2')
   s.add_development_dependency('sdoc', '~> 0.4.1')
   s.add_development_dependency('pry')
+  s.add_development_dependency('coveralls')
+
 
   s.extra_rdoc_files  = %w[.document README.rdoc]
   s.test_files        = (s.files & (Dir['spec/**/*_spec.rb'] + Dir['test/test_*.rb']) )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'coveralls'
+Coveralls.wear!
+
 puts "rspec #{RSpec::Core::Version::STRING}"
 if RSpec::Core::Version::STRING[0] == '3'
   require 'rspec/its'
@@ -10,3 +13,4 @@ if RSpec::Core::Version::STRING[0] == '3'
 end
 
 require 'packetfu/common'
+


### PR DESCRIPTION
Add coveralls so we know our unit-test coverage levels at all times.  This will also make PRs more visible when someone adds code, but no associated tests and make test coverage a first class citizen in the project.