### PR TITLE
Fix incorrect requires on protocols when this is used as a gem

### DIFF
--- a/lib/packetfu/protos.rb
+++ b/lib/packetfu/protos.rb
@@ -1,3 +1,5 @@
 # Picks up all the protocols defined in the protos subdirectory
-path = File.expand_path("lib/packetfu/protos/*.rb")
-Dir.glob(path).each {|file| require file}
+path = File.expand_path(File.join(File::dirname(__FILE__), "protos", "*.rb"))
+Dir.glob(path).each do |file|
+  require file
+end


### PR DESCRIPTION
The commit 0085cf0b01ed668bf6b5e9eb0d89511c4ba9847a to cleanup library loading has a problem in that it uses a path relative to the current working directory, rather than relative to the gem itself.

This causes all of the proto requires to be skipped when this is used in the context of a gem. This PR fixes the search path to be relative to protos.rb itself.