### PR TITLE
Oops'ed the version tag. Dot, not dash.

### DIFF
--- a/lib/packetfu/version.rb
+++ b/lib/packetfu/version.rb
@@ -2,7 +2,7 @@
 module PacketFu
 
   # Check the repo's for version release histories
-  VERSION = "1.1.13-pre"
+  VERSION = "1.1.13.pre"
 
   # Returns PacketFu::VERSION
   def self.version


### PR DESCRIPTION
The version name should be dotted, not dashed. Otherwise, you end up gem building `packetfu-1.1.13.pre.pre.gem` which is dumb.