### PR TITLE
Fix broken ackscan example, calling o4= seems to be deprecated

### DIFF
--- a/examples/ackscan.rb
+++ b/examples/ackscan.rb
@@ -31,12 +31,13 @@ def gen_packets
   pkt.tcp_dst=81
   pkt_array = []
   256.times do |i|
-   pkt.ip_dst.o4=i
-   pkt.tcp_src = rand(5000 - 1025) + 1025
- 	 pkt.recalc
- 	 pkt_array << pkt.to_s
- 	end
- 	pkt_array
+    oa = PacketFu::IPHeader.octet_array(pkt.ip_dst)[0,3] + ["#{i}"]
+    pkt.ip_dst = IPAddr.new(oa.join '.').to_i
+    pkt.tcp_src = rand(5000 - 1025) + 1025
+    pkt.recalc
+    pkt_array << pkt.to_s
+  end
+  pkt_array
 end
 
 do_scan


### PR DESCRIPTION
The line `pkt.ip_dst.o4=i` was breaking like: 

```
ackscan.rb:36:in `block in gen_packets': undefined method `o4=' for 3512050944:Integer (NoMethodError)
        from ackscan.rb:33:in `times'
        from ackscan.rb:33:in `gen_packets'
        from ackscan.rb:18:in `do_scan'
        from ackscan.rb:44:in `<main>'
```

I traced this over to the `IPHeader` class and it looks like `ip_dst` is no longer returning a `PacketFu::Octets` object anymore. Furthermore the `o4=` method seems to be deprecated on that object anyway. 

My fix may not be the most elegant way to solve this but I am pretty new to using this library.

I did not add any tests because this was an example file which are untested as best as I can tell. 