### PR TITLE
Update travis rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_install:
  - sudo apt-get install libpcap-dev -qq
 rvm:
   - 2.1
-  - 2.2
-  - 2.3.3
+  - 2.2.7
+  - 2.3.4
   - 2.4.0
   - 2.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 before_install:
  - sudo apt-get install libpcap-dev -qq
 rvm:
-  - 2.1
   - 2.2.7
   - 2.3.4
   - 2.4.0


### PR DESCRIPTION
This does two things...

- For supported rubies, let's test the lastest available versions (assuming they are the best)
- For Ruby 2.1 remove it, it's no longer a supported Ruby