### PR TITLE
Remove TTL check in HSRPPacket.can_parse? - Fix #185

### DIFF
--- a/lib/packetfu/protos/hsrp.rb
+++ b/lib/packetfu/protos/hsrp.rb
@@ -52,11 +52,10 @@ module PacketFu
       return false unless UDPPacket.can_parse? str
       temp_packet = UDPPacket.new
       temp_packet.read(str)
-      if temp_packet.ip_ttl == 1 and [temp_packet.udp_sport,temp_packet.udp_dport] == [1985,1985] 
-        return true
-      else 
-        return false
-      end
+      return false unless temp_packet.eth_daddr == '01:00:5e:00:00:02' 
+      return false unless temp_packet.ip_daddr == '224.0.0.2' 
+      return false unless [temp_packet.udp_sport,temp_packet.udp_dport] == [1985,1985]   
+      true
     end
 
     def initialize(args={})


### PR DESCRIPTION
## Summary

Remove TTL check in `HSRPPacket.can_parse?`

Check the `eth_daddr` and `ip_daddr` instead:

* `temp_packet.eth_daddr == '01:00:5e:00:00:02'`
* `temp_packet.ip_daddr == '224.0.0.2'`

Fixes #185


## Description

A HSRP message with a TTL larger than 1 is still a valid HSRP packet.

Rather than check the TTL, it might be a safer assumption to check whether the packet is broadcast traffic:

* `temp_packet.eth_daddr == '01:00:5e:00:00:02'`
* `temp_packet.ip_daddr == '224.0.0.2'`

My thinking is that a HSRP router should never forward a HSRP message with a TTL which exceeds 1. Where as the HSRP sender may include a higher TTL for various reasons, as evidenced by sample PCAPs and the `hsrp` utility.

## Testing

Run the following with and without the patch.

```sh
hsrp -d 224.0.0.2 -v 192.168.0.1 -g 1 -i eth0 -S 192.168.0.123 -a "cisco" 
```
