### PR TITLE
forget about Ruby 1.8

### DIFF
--- a/lib/packetfu/config.rb
+++ b/lib/packetfu/config.rb
@@ -34,7 +34,7 @@ module PacketFu
 
     def initialize(args={})
       if Process.euid.zero?
-        @iface = args[:iface] || ENV['IFACE'] || Pcap.lookupdev || "lo" 
+        @iface = args[:iface] || ENV['IFACE'] || Pcap.lookupdev || "lo"
       end
       @pcapfile = "/tmp/out.pcap"
       args.each_pair { |k,v| self.instance_variable_set(("@#{k}"),v) }
@@ -43,7 +43,7 @@ module PacketFu
     # Returns all instance variables as a hash (including custom variables set at initialization).
     def config(arg=nil)
       if arg
-        arg.each_pair {|k,v| self.instance_variable_set(("@" + k.to_s).intern, v)}
+        arg.each_pair {|k,v| self.instance_variable_set(("@" + k.to_s).to_sym, v)}
       else
         config_hash = {}
         self.instance_variables.each do |v|

--- a/lib/packetfu/protos/arp.rb
+++ b/lib/packetfu/protos/arp.rb
@@ -52,7 +52,7 @@ module PacketFu
 
       # Please send more flavors to todb+packetfu@planb-security.net.
       # Most of these initial fingerprints come from one (1) sample.
-      case (args[:flavor].nil?) ? :nil : args[:flavor].to_s.downcase.intern
+      case (args[:flavor].nil?) ? :nil : args[:flavor].to_s.downcase.to_sym
       when :windows; @arp_header.body = "\x00" * 64				# 64 bytes of padding
       when :linux; @arp_header.body = "\x00" * 4 +				# 32 bytes of padding
         "\x00\x07\x5c\x14" + "\x00" * 4 +

--- a/lib/packetfu/protos/icmp/header.rb
+++ b/lib/packetfu/protos/icmp/header.rb
@@ -1,11 +1,11 @@
 # -*- coding: binary -*-
 module PacketFu
-  # ICMPHeader is a complete ICMP struct, used in ICMPPacket. ICMP is 
+  # ICMPHeader is a complete ICMP struct, used in ICMPPacket. ICMP is
   # typically used for network administration and connectivity testing.
   #
-  # For more on ICMP packets, see 
+  # For more on ICMP packets, see
   # http://www.networksorcery.com/enp/protocol/icmp.htm
-  # 
+  #
   # ==== Header Definition
   #
   #   Int8    :icmp_type                        # Type
@@ -49,7 +49,7 @@ module PacketFu
     def icmp_code=(i); typecast i; end
     # Getter for the code.
     def icmp_code; self[:icmp_code].to_i; end
-    # Setter for the checksum. Note, this is calculated automatically with 
+    # Setter for the checksum. Note, this is calculated automatically with
     # icmp_calc_sum.
     def icmp_sum=(i); typecast i; end
     # Getter for the checksum.
@@ -68,12 +68,10 @@ module PacketFu
       checksum = 0xffff - checksum
       checksum == 0 ? 0xffff : checksum
     end
-    
+
     # Recalculates the calculatable fields for ICMP.
     def icmp_recalc(arg=:all)
-      # How silly is this, you can't intern a symbol in ruby 1.8.7pl72?
-      # I'm this close to monkey patching Symbol so you can force it...
-      arg = arg.intern if arg.respond_to? :intern
+      arg = arg.intern
       case arg
       when :icmp_sum
         self.icmp_sum=icmp_calc_sum

--- a/lib/packetfu/protos/icmp/header.rb
+++ b/lib/packetfu/protos/icmp/header.rb
@@ -70,8 +70,8 @@ module PacketFu
     end
 
     # Recalculates the calculatable fields for ICMP.
-    def icmp_recalc(arg=:all)
-      arg = arg.intern
+    def icmp_recalc(arg = :all)
+      arg = arg.to_sym
       case arg
       when :icmp_sum
         self.icmp_sum=icmp_calc_sum

--- a/lib/packetfu/protos/icmp/header.rb
+++ b/lib/packetfu/protos/icmp/header.rb
@@ -71,8 +71,7 @@ module PacketFu
 
     # Recalculates the calculatable fields for ICMP.
     def icmp_recalc(arg = :all)
-      arg = arg.to_sym
-      case arg
+      case arg.to_sym
       when :icmp_sum
         self.icmp_sum=icmp_calc_sum
       when :all

--- a/lib/packetfu/protos/icmpv6.rb
+++ b/lib/packetfu/protos/icmpv6.rb
@@ -85,8 +85,7 @@ module PacketFu
 
     # Recalculates the calculatable fields for ICMPv6.
     def icmpv6_recalc(arg = :all)
-      arg = arg.to_sym
-      case arg
+      case arg.to_sym
       when :icmpv6_sum
         self.icmpv6_sum = icmpv6_calc_sum
       when :all

--- a/lib/packetfu/protos/icmpv6.rb
+++ b/lib/packetfu/protos/icmpv6.rb
@@ -84,8 +84,8 @@ module PacketFu
     end
 
     # Recalculates the calculatable fields for ICMPv6.
-    def icmpv6_recalc(arg=:all)
-      arg = arg.intern
+    def icmpv6_recalc(arg = :all)
+      arg = arg.to_sym
       case arg
       when :icmpv6_sum
         self.icmpv6_sum = icmpv6_calc_sum

--- a/lib/packetfu/protos/icmpv6.rb
+++ b/lib/packetfu/protos/icmpv6.rb
@@ -23,7 +23,7 @@ module PacketFu
   #  icmpv6_pkt.ipv6_saddr="2000::1234"
   #  icmpv6_pkt.ipv6_daddr="2000::5678"
   #
-  #  icmpv6_pkt.recalc	
+  #  icmpv6_pkt.recalc
   #  icmpv6_pkt.to_f('/tmp/icmpv6.pcap')
   #
   # == Parameters
@@ -85,7 +85,7 @@ module PacketFu
 
     # Recalculates the calculatable fields for ICMPv6.
     def icmpv6_recalc(arg=:all)
-      arg = arg.intern if arg.respond_to? :intern
+      arg = arg.intern
       case arg
       when :icmpv6_sum
         self.icmpv6_sum = icmpv6_calc_sum

--- a/lib/packetfu/protos/udp/header.rb
+++ b/lib/packetfu/protos/udp/header.rb
@@ -66,9 +66,9 @@ module PacketFu
     end
 
     # Recalculates calculated fields for UDP.
-    def udp_recalc(args=:all)
-      arg = arg.intern
-      case args
+    def udp_recalc(arg = :all)
+      arg = arg.to_sym
+      case arg
       when :udp_len
         self.udp_len = udp_calc_len
       when :all

--- a/lib/packetfu/protos/udp/header.rb
+++ b/lib/packetfu/protos/udp/header.rb
@@ -10,7 +10,7 @@ module PacketFu
   #  Int16   :udp_src
   #  Int16   :udp_dst
   #  Int16   :udp_len  Default: calculated
-  #  Int16   :udp_sum  Default: 0. Often calculated. 
+  #  Int16   :udp_sum  Default: 0. Often calculated.
   #  String  :body
   class UDPHeader < Struct.new(:udp_src, :udp_dst, :udp_len, :udp_sum, :body)
 
@@ -67,7 +67,7 @@ module PacketFu
 
     # Recalculates calculated fields for UDP.
     def udp_recalc(args=:all)
-      arg = arg.intern if arg.respond_to? :intern
+      arg = arg.intern
       case args
       when :udp_len
         self.udp_len = udp_calc_len
@@ -92,7 +92,7 @@ module PacketFu
     def udp_dport
       self.udp_dst
     end
-    
+
     # Equivalent to udp_dst=
     def udp_dport=(arg)
       self.udp_dst=(arg)

--- a/lib/packetfu/protos/udp/header.rb
+++ b/lib/packetfu/protos/udp/header.rb
@@ -67,8 +67,7 @@ module PacketFu
 
     # Recalculates calculated fields for UDP.
     def udp_recalc(arg = :all)
-      arg = arg.to_sym
-      case arg
+      case arg.to_sym
       when :udp_len
         self.udp_len = udp_calc_len
       when :all

--- a/lib/packetfu/structfu.rb
+++ b/lib/packetfu/structfu.rb
@@ -18,7 +18,7 @@ module StructFu
   # expected type for that element.
   def typecast(i)
     c = caller[0].match(/.*`([^']+)='/)[1]
-    self[c.intern].read i
+    self[c.to_sym].read i
   end
 
   # Used like typecast(), but specifically for casting Strings to StructFu::Strings.


### PR DESCRIPTION
This removes some comments and workarounds for obsolete Ruby versions.

Best viewed without whitespace changes (editor cleans up trailing whitespace on save):
https://github.com/packetfu/packetfu/pull/188/files?w=1