### PR TITLE
Remove TTL check in HSRPPacket.can_parse? - Fix #185

### DIFF
--- a/lib/packetfu/protos/hsrp.rb
+++ b/lib/packetfu/protos/hsrp.rb
@@ -52,11 +52,8 @@ module PacketFu
       return false unless UDPPacket.can_parse? str
       temp_packet = UDPPacket.new
       temp_packet.read(str)
-      if temp_packet.ip_ttl == 1 and [temp_packet.udp_sport,temp_packet.udp_dport] == [1985,1985] 
-        return true
-      else 
-        return false
-      end
+      return false unless temp_packet.ip_daddr == '224.0.0.2'
+      return false unless [temp_packet.udp_sport,temp_packet.udp_dport] == [1985,1985]
     end
 
     def initialize(args={})


### PR DESCRIPTION
## Summary

This PR modifies `HSRPPacket.can_parse?` conditionals to use `ip_daddr == '224.0.0.2'` rather than `ip_ttl == 1`.

Fixes #185


## Description

A HSRP message with a TTL larger than 1 is still a valid HSRP packet, where as a packet destined for a multicast address other than `224.0.0.2` is unlikely to be a HSRP version 0 packet.

My thinking is that a correct HSRP implementation should never forward a HSRP message with a TTL which exceeds 1. Where as the HSRP sender may include a higher TTL for various reasons, as evidenced by sample PCAPs and the `hsrp` utility.

HSRP version 2 makes use of a different multicast address, however the HSRP library in PacketFu only works for HSRP version 0. It does not work for HSRP version 2.

* The PacketFu HSRP library performs no version check.
* HSRP version 2 is not backwards compatible with HSRP version 0.
* HSRP version 2 typically operates on port 2029 which wouldn't be parsed by this library, which checks port 1985.

For these reasons, using the multicast address should be a safer assumption than using the TTL for detecting HSRP traffic.


## Testing

Run the following with and without the patch.

```sh
hsrp -d 224.0.0.2 -v 192.168.0.1 -g 1 -i eth0 -S 192.168.0.123 -a "cisco" 
```

Sample PCAPs:

* https://wiki.wireshark.org/SampleCaptures?action=AttachFile&do=get&target=hsrp.pcap
* https://wiki.wireshark.org/SampleCaptures?action=AttachFile&do=get&target=hsrp-and-ospf-in-LAN
* https://raw.githubusercontent.com/kholia/my-pcaps/master/captures/HSRP/HSRP-auth-md5-openwall.pcap
* https://raw.githubusercontent.com/kholia/my-pcaps/master/captures/HSRP/plain-HSRP.pcap
* https://github.com/kholia/my-pcaps/raw/master/HSRP/packet-captures/20-0.0-1409591337.pcap

