### PR TITLE
Drop support rubies redundancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,7 @@ Capture from an interface with show_live or whatever.
 
 This project is integrated with travis-ci and is regularly tested to work with the following rubies:
 
-- 2.2.7
-- 2.3.4
-- 2.4.0
-- 2.4.1
-
-To checkout the current build status for these rubies, click [here](https://travis-ci.org/packetfu/packetfu).
+To checkout the current build status and what rubies we're currently supporting, click [here](https://travis-ci.org/packetfu/packetfu).
 
 ## Author
 


### PR DESCRIPTION
Every now and again, we update the supported rubies and it just seems odd to maintain this list in two places when realistically one place and linking people to that place is probably just fine.