### PR TITLE
Add OSX build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,27 @@
 language: ruby
-before_install:
- - sudo apt-get install libpcap-dev -qq
 matrix:
   include:
   - os: linux
     rvm: 2.4.1
-  - os: osx
-    rvm: 2.4.1
+    before_install:
+      - sudo apt-get install libpcap-dev -qq
   - os: linux
     rvm: 2.4.0
-  - os: osx
-    rvm: 2.4.0
+    before_install:
+      - sudo apt-get install libpcap-dev -qq
   - os: linux
     rvm: 2.3.4
-  - os: osx
-    rvm: 2.3.4
+    before_install:
+      - sudo apt-get install libpcap-dev -qq
   - os: linux
     rvm: 2.2.7
+    before_install:
+      - sudo apt-get install libpcap-dev -qq
+  - os: osx
+    rvm: 2.4.1
+  - os: osx
+    rvm: 2.4.0
+  - os: osx
+    rvm: 2.3.4
   - os: osx
     rvm: 2.2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,19 @@ before_install:
  - sudo apt-get install libpcap-dev -qq
 matrix:
   include:
-  - rvm: 2.4.1
-  - rvm: 2.4.0
-  - rvm: 2.3.4
-  - rvm: 2.2.7
+  - os: linux
+    rvm: 2.4.1
+  - os: osx
+    rvm: 2.4.1
+  - os: linux
+    rvm: 2.4.0
+  - os: osx
+    rvm: 2.4.0
+  - os: linux
+    rvm: 2.3.4
+  - os: osx
+    rvm: 2.3.4
+  - os: linux
+    rvm: 2.2.7
+  - os: osx
+    rvm: 2.2.7

--- a/README.md
+++ b/README.md
@@ -120,7 +120,11 @@ This project is integrated with travis-ci and is regularly tested to work with t
 
 To checkout the current build status for these rubies, click [here](https://travis-ci.org/packetfu/packetfu).
 
-## Author
+## Supported OSs
+
+This project is designed for use on Linux (Ubuntu|RHEL|BSD primarily) and OSX platforms and it is the intention of the PacketFu team to support those OSs to ensure PacketFu runs on them.  That said, PacketFu can and has been known to run on Windows as well as other unix-style platforms, but it's not actively supported in the sense that we may help from the community to help fill that gap.  If that is something you are interested in helping with, we welcome your support.
+
+## Authors
 
 PacketFu is maintained primarily by Tod Beardsley todb@packetfu.com and
 Jonathan Claudius claudijd@yahoo.com, with help from Open Source Land.


### PR DESCRIPTION
For the most part, we support Linux and OSX builds.  This is mainly a function of who's developing on PacketFu and where their priorities lie with the little time we can devote to it.  This attempts to add unit-tests for those two OS types in the interest of making sure new code doesn't introduce OS specific bugs that don't affect the default linux build platform we are using in Travis.