### PR TITLE
Add tests for newer ruby versions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,73 @@
+name: Verify
+
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  verify:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+        ruby:
+          - '2.7'
+          - '3.0'
+          - '3.1'
+          - '3.2'
+          - '3.3.0-preview1'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+
+    name: ${{ matrix.os }} - Ruby ${{ matrix.ruby }}
+
+    env:
+      COVERALLS_SKIP: "true"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install libpcap-dev
+
+      - name: Setup Ruby
+        env:
+          BUNDLE_WITHOUT: "coverage development"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: false
+
+      - name: Run tests
+        run: |
+          bundle install
+          bundle exec rspec
+

--- a/examples/100kpackets.rb
+++ b/examples/100kpackets.rb
@@ -5,7 +5,7 @@
 # reading and writing packets to and from pcap files.
 
 # Usage:
-# ruby examples/100kpackets.rb 
+# ruby examples/100kpackets.rb
 
 # Path setting slight of hand:
 $: << File.expand_path("../../lib", __FILE__)
@@ -13,7 +13,7 @@ require 'packetfu'
 
 puts "Generating packets... (#{Time.now.utc})"
 
-File.unlink("/tmp/out.pcap") if File.exists? "/tmp/out.pcap"
+File.unlink("/tmp/out.pcap") if File.exist? "/tmp/out.pcap"
 start_time = Time.now.utc
 count = 0
 

--- a/examples/pcap2pcapng.rb
+++ b/examples/pcap2pcapng.rb
@@ -9,11 +9,11 @@ require 'packetfu'
 pcap_filename = ARGV[0].chomp
 pcapng_filename = ARGV[1].chomp
 
-unless File.exists?(pcap_filename)
+unless File.exist?(pcap_filename)
   puts "PCAP input file #{pcap_filename} could not be found"
 end
 
-if File.exists?(pcapng_filename)
+if File.exist?(pcapng_filename)
   puts "PCAP-NG output file #{pcap_filename} already exists"
   puts "Do you wish to overwrite the file? (Y/N, Default = N)"
   STDOUT.flush

--- a/examples/readpcap.rb
+++ b/examples/readpcap.rb
@@ -10,7 +10,7 @@ include PacketFu
 
 pcap_filename = ARGV[0] || 'test/sample.pcap'
 
-unless File.exists?(pcap_filename)
+unless File.exist?(pcap_filename)
   puts "PCAP input file '#{pcap_filename}' could not be found"
   exit 1
 end

--- a/lib/packetfu/packet.rb
+++ b/lib/packetfu/packet.rb
@@ -95,7 +95,7 @@ module PacketFu
       filename ||= 'out.pcap'
       mode = mode.to_s[0,1] + "b"
       raise ArgumentError, "Unknown mode: #{mode.to_s}" unless mode =~ /^[wa]/
-      if(mode == 'w' || !(File.exists?(filename)))
+      if(mode == 'w' || !(File.exist?(filename)))
         data = [PcapHeader.new, self.to_pcap].map {|x| x.to_s}.join
       else
         data = self.to_pcap
@@ -297,7 +297,7 @@ module PacketFu
     def hexify(str)
       str.force_encoding(Encoding::BINARY) if str.respond_to? :force_encoding
       hexascii_lines = str.to_s.unpack("H*")[0].scan(/.{1,32}/)
-      regex = Regexp.new('[\x00-\x1f\x7f-\xff]', nil, 'n')
+      regex = Regexp.new('[\x00-\x1f\x7f-\xff]'.force_encoding('ASCII-8BIT'), Regexp::NOENCODING)
       chars = str.to_s.gsub(regex,'.')
       chars_lines = chars.scan(/.{1,16}/)
       ret = []

--- a/lib/packetfu/pcap.rb
+++ b/lib/packetfu/pcap.rb
@@ -6,7 +6,7 @@ module StructFu
   # Set the endianness for the various Int classes. Takes either :little or :big.
   def set_endianness(e=nil)
     unless [:little, :big].include? e
-      raise ArgumentError, "Unknown endianness for #{self.class}" 
+      raise ArgumentError, "Unknown endianness for #{self.class}"
     end
     @int64 = e == :little ? Int64le : Int64be
     @int32 = e == :little ? Int32le : Int32be
@@ -26,11 +26,11 @@ end
 module PacketFu
 
   # PcapHeader represents the header portion of a libpcap file (the packets
-  # themselves are in the PcapPackets array). See 
+  # themselves are in the PcapPackets array). See
   # http://wiki.wireshark.org/Development/LibpcapFileFormat for details.
   #
   # Depending on the endianness (set with :endian), elements are either
-  # :little endian or :big endian. 
+  # :little endian or :big endian.
   #
   # ==== PcapHeader Definition
   #
@@ -52,13 +52,13 @@ module PacketFu
 
     def initialize(args={})
       set_endianness(args[:endian] ||= :little)
-      init_fields(args) 
-      super(args[:endian], args[:magic], args[:ver_major], 
-            args[:ver_minor], args[:thiszone], args[:sigfigs], 
+      init_fields(args)
+      super(args[:endian], args[:magic], args[:ver_major],
+            args[:ver_minor], args[:thiszone], args[:sigfigs],
             args[:snaplen], args[:network])
     end
-    
-    # Called by initialize to set the initial fields. 
+
+    # Called by initialize to set the initial fields.
     def init_fields(args={})
       args[:magic] = @int32.new(args[:magic] || PcapHeader::MAGIC_INT32)
       args[:ver_major] = @int16.new(args[:ver_major] || 2)
@@ -82,7 +82,7 @@ module PacketFu
       force_binary(str)
       return self if str.nil?
       str.force_encoding(Encoding::BINARY) if str.respond_to? :force_encoding
-      if str[0,4] == self[:magic].to_s 
+      if str[0,4] == self[:magic].to_s
         self[:magic].read str[0,4]
         self[:ver_major].read str[4,2]
         self[:ver_minor].read str[6,2]
@@ -114,7 +114,7 @@ module PacketFu
       super(args[:endian], args[:sec], args[:usec])
     end
 
-    # Called by initialize to set the initial fields. 
+    # Called by initialize to set the initial fields.
     def init_fields(args={})
       args[:sec] = @int32.new(args[:sec])
       args[:usec] = @int32.new(args[:usec])
@@ -156,7 +156,7 @@ module PacketFu
            args[:orig_len], args[:data])
     end
 
-    # Called by initialize to set the initial fields. 
+    # Called by initialize to set the initial fields.
     def init_fields(args={})
       args[:timestamp] = Timestamp.new(:endian => args[:endian]).read(args[:timestamp])
       args[:incl_len] = args[:incl_len].nil? ? @int32.new(args[:data].to_s.size) : @int32.new(args[:incl_len])
@@ -197,8 +197,8 @@ module PacketFu
       str.force_encoding Encoding::BINARY if str.respond_to? :force_encoding
     end
 
-    # Reads a string to populate the object. Note, this read takes in the 
-    # whole pcap file, since we need to see the magic to know what 
+    # Reads a string to populate the object. Note, this read takes in the
+    # whole pcap file, since we need to see the magic to know what
     # endianness we're dealing with.
     def read(str)
       force_binary(str)
@@ -226,7 +226,7 @@ module PacketFu
 
   end
 
-  # PcapFile is a complete libpcap file struct, made up of two elements, a 
+  # PcapFile is a complete libpcap file struct, made up of two elements, a
   # PcapHeader and PcapPackets.
   #
   # See http://wiki.wireshark.org/Development/LibpcapFileFormat
@@ -240,7 +240,7 @@ module PacketFu
 
     class << self
 
-      # Takes a given file and returns an array of the packet bytes. Here 
+      # Takes a given file and returns an array of the packet bytes. Here
       # for backwards compatibilty.
       def file_to_array(fname)
         PcapFile.new.file_to_array(:f => fname)
@@ -248,9 +248,9 @@ module PacketFu
 
       # Takes a given file name, and reads out the packets. If given a block,
       # it will yield back a PcapPacket object per packet found.
-      def read(fname,&block) 
+      def read(fname,&block)
         file_header = PcapHeader.new
-        pcap_packets = PcapPackets.new 
+        pcap_packets = PcapPackets.new
         unless File.readable? fname
           raise ArgumentError, "Cannot read file `#{fname}'"
         end
@@ -279,13 +279,13 @@ module PacketFu
         block ? packet_count : pcap_packets
       end
 
-      # Takes a filename, and an optional block. If a block is given, 
+      # Takes a filename, and an optional block. If a block is given,
       # yield back the raw packet data from the given file. Otherwise,
       # return an array of parsed packets.
       def read_packet_bytes(fname,&block)
         count = 0
         packets = [] unless block
-        read(fname) do |packet| 
+        read(fname) do |packet|
           if block
             count += 1
             yield packet.data.to_s
@@ -296,7 +296,7 @@ module PacketFu
         block ? count : packets
       end
 
-      alias :file_to_array :read_packet_bytes 
+      alias :file_to_array :read_packet_bytes
 
       # Takes a filename, and an optional block. If a block is given,
       # yield back parsed packets from the given file. Otherwise, return
@@ -307,7 +307,7 @@ module PacketFu
       def read_packets(fname,&block)
         count = 0
         packets = [] unless block
-        read_packet_bytes(fname) do |packet| 
+        read_packet_bytes(fname) do |packet|
           if block
             count += 1
             yield Packet.parse(packet)
@@ -326,7 +326,7 @@ module PacketFu
       super(args[:endian], args[:head], args[:body])
     end
 
-    # Called by initialize to set the initial fields. 
+    # Called by initialize to set the initial fields.
     def init_fields(args={})
       args[:head] = PcapHeader.new(:endian => args[:endian]).read(args[:head])
       args[:body] = PcapPackets.new(:endian => args[:endian]).read(args[:body])
@@ -354,7 +354,7 @@ module PacketFu
 
     # Clears the contents of the PcapFile prior to reading in a new string.
     def read!(str)
-      clear	
+      clear
       force_binary(str)
       self.read str
     end
@@ -381,7 +381,7 @@ module PacketFu
 
     # file_to_array() translates a libpcap file into an array of packets.
     # Note that this strips out pcap timestamps -- if you'd like to retain
-    # timestamps and other libpcap file information, you will want to 
+    # timestamps and other libpcap file information, you will want to
     # use read() instead.
     def file_to_array(args={})
       filename = args[:filename] || args[:file] || args[:f]
@@ -469,7 +469,7 @@ module PacketFu
       end
       append = args[:append]
       if append
-        if File.exists? filename
+        if File.exist? filename
           File.open(filename,'ab') {|file| file.write(self.body.to_s)}
         else
           File.open(filename,'wb') {|file| file.write(self.to_s)}

--- a/lib/packetfu/pcapng/file.rb
+++ b/lib/packetfu/pcapng/file.rb
@@ -144,7 +144,7 @@ module PacketFu
 
         append = args[:append]
         mode = ''
-        if append and ::File.exists? filename
+        if append and ::File.exist? filename
           mode = 'ab'
         else
           mode = 'wb'

--- a/lib/packetfu/protos/lldp.rb
+++ b/lib/packetfu/protos/lldp.rb
@@ -8,7 +8,7 @@ require 'packetfu/protos/lldp/mixin'
 module PacketFu
 
   class LLDPPacket < Packet
-    MAGIC = Regexp.new("^\x01\x80\xc2\x00\x00[\x0e\x03\x00]", nil, "n")
+    MAGIC = Regexp.new("^\x01\x80\xc2\x00\x00[\x0e\x03\x00]".force_encoding('ASCII-8BIT'), Regexp::NOENCODING)
     include ::PacketFu::EthHeaderMixin
     include ::PacketFu::LLDPHeaderMixin
 

--- a/packetfu.gemspec
+++ b/packetfu.gemspec
@@ -1,4 +1,3 @@
-require 'rake'
 require './lib/packetfu/version'
 
 Gem::Specification.new do |s|
@@ -16,14 +15,13 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split($/)
   s.license     = 'BSD-3-Clause'
   s.required_ruby_version = '>= 2.1.0'
-  s.add_dependency('pcaprub', '~> 0.12')
-  s.add_development_dependency('rake', '~> 12.0')
+  s.add_dependency('pcaprub', '~> 0.13.1')
+  s.add_development_dependency('rake')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('rspec-its', '~> 1.2')
   s.add_development_dependency('sdoc', '~> 0.4')
-  s.add_development_dependency('pry', '~> 0.10')
+  s.add_development_dependency('pry-byebug')
   s.add_development_dependency('coveralls', '~> 0.8')
-
 
   s.extra_rdoc_files  = %w[.document README.md]
   s.test_files        = (s.files & (Dir['spec/**/*_spec.rb'] + Dir['test/test_*.rb']) )

--- a/spec/arp_spec.rb
+++ b/spec/arp_spec.rb
@@ -190,7 +190,7 @@ describe ARPPacket do
       expect(@temp_file.read).to eql("")
 
       @arp_packet.to_f(@temp_file.path, 'a')
-      expect(File.exists?(@temp_file.path)).to be(true)
+      expect(File.exist?(@temp_file.path)).to be(true)
       expect(@temp_file.read.size).to be >= 76
     end
   end

--- a/spec/eth_spec.rb
+++ b/spec/eth_spec.rb
@@ -130,7 +130,7 @@ describe EthPacket do
       expect(@temp_file.read).to eql("")
 
       @eth_packet.to_f(@temp_file.path, 'a')
-      expect(File.exists?(@temp_file.path))
+      expect(File.exist?(@temp_file.path))
       expect(@temp_file.read.size).to be >= 30
     end
 

--- a/spec/icmp_spec.rb
+++ b/spec/icmp_spec.rb
@@ -87,7 +87,7 @@ describe ICMPPacket, "when read from a pcap file" do
       expect(@temp_file.read).to eql("")
 
       @icmp_packet.to_f(@temp_file.path, 'a')
-      expect(File.exists?(@temp_file.path))
+      expect(File.exist?(@temp_file.path))
       expect(@temp_file.read.size).to be >= 79
     end
 

--- a/spec/icmpv6_spec.rb
+++ b/spec/icmpv6_spec.rb
@@ -80,7 +80,7 @@ describe ICMPv6Packet, "when read from a pcap file" do
       expect(@temp_file.read).to eql("")
 
       @icmpv6_packet.to_f(@temp_file.path, 'a')
-      expect(File.exists?(@temp_file.path))
+      expect(File.exist?(@temp_file.path))
       expect(@temp_file.read.size).to be >= 79
     end
 

--- a/spec/ip_spec.rb
+++ b/spec/ip_spec.rb
@@ -23,15 +23,15 @@ describe IPHeader do
       expect(@ip_header.ip_sum).to eql(65535)
       expect(@ip_header.ip_src).to eql(0)
       expect(@ip_header.ip_dst).to eql(0)
-      expect(@ip_header.ip_src).to be_a(Integer) 
-      expect(@ip_header.ip_dst).to be_a(Integer) 
+      expect(@ip_header.ip_src).to be_a(Integer)
+      expect(@ip_header.ip_dst).to be_a(Integer)
       expect(@ip_header.body).to eql("")
     end
 
     it "should parse a raw IPHeader" do
       raw_header = "\x45\x10\x00\x4f\x16\xa9\x40\x00\x40\x06\xa2\x9c\xc0\xa8\x00\x02\xc0\xa8\x00\x01"
       @ip_header.read(raw_header)
-     
+
       expect(@ip_header.ip_v).to eql(4)
       expect(@ip_header.ip_hl).to eql(5)
       expect(@ip_header.ip_tos).to eql(16)
@@ -42,8 +42,8 @@ describe IPHeader do
       expect(@ip_header.ip_sum).to eql(41628)
       expect(@ip_header.ip_src).to eql(3232235522)
       expect(@ip_header.ip_dst).to eql(3232235521)
-      expect(@ip_header.ip_src).to be_a(Integer) 
-      expect(@ip_header.ip_dst).to be_a(Integer) 
+      expect(@ip_header.ip_src).to be_a(Integer)
+      expect(@ip_header.ip_dst).to be_a(Integer)
       expect(@ip_header.body).to eql("")
     end
 
@@ -98,7 +98,7 @@ describe IPPacket do
       expect(@temp_file.read).to eql("")
 
       @ip_packet.to_f(@temp_file.path, 'a')
-      expect(File.exists?(@temp_file.path))
+      expect(File.exist?(@temp_file.path))
       expect(@temp_file.read.size).to be >= 49
     end
   end

--- a/spec/pcap_spec.rb
+++ b/spec/pcap_spec.rb
@@ -194,7 +194,7 @@ describe PcapFile do
 
     it "should read via #file_to_array and write via #to_f" do
       # TODO: Figure out why this is failing to write properly when converted to a Tempfile
-      File.unlink('out.pcap') if File.exists? 'out.pcap'
+      File.unlink('out.pcap') if File.exist? 'out.pcap'
       pcaps = PcapFile.new.file_to_array(:filename => 'test/sample.pcap')
       pcaps.each {|pkt|
         packet = Packet.parse pkt

--- a/spec/pcapng/file_spec.rb
+++ b/spec/pcapng/file_spec.rb
@@ -45,7 +45,7 @@ module PacketFu
         it 'yields xPB object per read packet' do
           idx = 0
           @pcapng.readfile(@file) do |pkt|
-            expect(pkt).to be_a(@Pcapng::EPB)
+            expect(pkt).to be_a(PcapNG::EPB)
             idx += 1
           end
           expect(idx).to eq(11)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
-require 'coveralls'
-Coveralls.wear!
+unless ENV['SKIP_COVERALLS']
+  require 'coveralls'
+  Coveralls.wear!
+end
 
 puts "rspec #{RSpec::Core::Version::STRING}"
 if RSpec::Core::Version::STRING[0] == '3'


### PR DESCRIPTION
closes https://github.com/packetfu/packetfu/issues/207

Adds support for Ruby 3.2.0, as well as adding CI support for verifying newer Ruby versions

Example passing output with Github actions:

<img width="1284" alt="image" src="https://github.com/packetfu/packetfu/assets/60357436/dc69d0f4-ef11-4025-aa35-2d8bdbe90a73">

Note: The tests currently pass on my fork/branch/repo, but won't be run by `packetfu/packetfu` until it's merged in