### PR TITLE
Ruby 3.4 compatibility fixes

### DIFF
--- a/lib/packetfu/protos/arp/header.rb
+++ b/lib/packetfu/protos/arp/header.rb
@@ -66,39 +66,39 @@ module PacketFu
     end
 
     # Setter for the ARP hardware type.
-    def arp_hw=(i); typecast i; end
+    def arp_hw=(i); self[:arp_hw].read(i); end
     # Getter for the ARP hardware type.
     def arp_hw; self[:arp_hw].to_i; end
     # Setter for the ARP protocol.
-    def arp_proto=(i); typecast i; end
+    def arp_proto=(i); self[:arp_proto].read(i); end
     # Getter for the ARP protocol.
     def arp_proto; self[:arp_proto].to_i; end
     # Setter for the ARP hardware type length.
-    def arp_hw_len=(i); typecast i; end
+    def arp_hw_len=(i); self[:arp_hw_len].read(i); end
     # Getter for the ARP hardware type length.
     def arp_hw_len; self[:arp_hw_len].to_i; end
     # Setter for the ARP protocol length.
-    def arp_proto_len=(i); typecast i; end
+    def arp_proto_len=(i); self[:arp_proto_len].read(i); end
     # Getter for the ARP protocol length.
     def arp_proto_len; self[:arp_proto_len].to_i; end
     # Setter for the ARP opcode. 
-    def arp_opcode=(i); typecast i; end
+    def arp_opcode=(i); self[:arp_opcode].read(i); end
     # Getter for the ARP opcode. 
     def arp_opcode; self[:arp_opcode].to_i; end
     # Setter for the ARP source MAC address.
-    def arp_src_mac=(i); typecast i; end
+    def arp_src_mac=(i); self[:arp_src_mac].read(i); end
     # Getter for the ARP source MAC address.
     def arp_src_mac; self[:arp_src_mac].to_s; end
     # Getter for the ARP source IP address.
-    def arp_src_ip=(i); typecast i; end
+    def arp_src_ip=(i); self[:arp_src_ip].read(i); end
     # Setter for the ARP source IP address.
     def arp_src_ip; self[:arp_src_ip].to_s; end
     # Setter for the ARP destination MAC address.
-    def arp_dst_mac=(i); typecast i; end
+    def arp_dst_mac=(i); self[:arp_dst_mac].read(i); end
     # Setter for the ARP destination MAC address.
     def arp_dst_mac; self[:arp_dst_mac].to_s; end
     # Setter for the ARP destination IP address.
-    def arp_dst_ip=(i); typecast i; end
+    def arp_dst_ip=(i); self[:arp_dst_ip].read(i); end
     # Getter for the ARP destination IP address.
     def arp_dst_ip; self[:arp_dst_ip].to_s; end
 

--- a/lib/packetfu/protos/eth/header.rb
+++ b/lib/packetfu/protos/eth/header.rb
@@ -157,15 +157,15 @@ module PacketFu
     end
 
     # Setter for the Ethernet destination address.
-    def eth_dst=(i); typecast(i); end
+    def eth_dst=(i); self[:eth_dst].read(i); end
     # Getter for the Ethernet destination address.
     def eth_dst; self[:eth_dst].to_s; end
     # Setter for the Ethernet source address.
-    def eth_src=(i); typecast(i); end
+    def eth_src=(i); self[:eth_src].read(i); end
     # Getter for the Ethernet source address.
     def eth_src; self[:eth_src].to_s; end
     # Setter for the Ethernet protocol number.
-    def eth_proto=(i); typecast(i); end
+    def eth_proto=(i); self[:eth_proto].read(i); end
     # Getter for the Ethernet protocol number.
     def eth_proto; self[:eth_proto].to_i; end
 

--- a/lib/packetfu/protos/hsrp/header.rb
+++ b/lib/packetfu/protos/hsrp/header.rb
@@ -68,35 +68,35 @@ module PacketFu
     end
 
     # Setter for the type.
-    def hsrp_version=(i); typecast i; end
+    def hsrp_version=(i); self[:hsrp_version].read(i); end
     # Getter for the type.
     def hsrp_version; self[:hsrp_version].to_i; end
     # Setter for the type.
-    def hsrp_opcode=(i); typecast i; end
+    def hsrp_opcode=(i); self[:hsrp_opcode].read(i); end
     # Getter for the type.
     def hsrp_opcode; self[:hsrp_opcode].to_i; end
     # Setter for the type.
-    def hsrp_state=(i); typecast i; end
+    def hsrp_state=(i); self[:hsrp_state].read(i); end
     # Getter for the type.
     def hsrp_state; self[:hsrp_state].to_i; end
     # Setter for the type.
-    def hsrp_hellotime=(i); typecast i; end
+    def hsrp_hellotime=(i); self[:hsrp_hellotime].read(i); end
     # Getter for the type.
     def hsrp_hellotime; self[:hsrp_hellotime].to_i; end
     # Setter for the type.
-    def hsrp_holdtime=(i); typecast i; end
+    def hsrp_holdtime=(i); self[:hsrp_holdtime].read(i); end
     # Getter for the type.
     def hsrp_holdtime; self[:hsrp_holdtime].to_i; end
     # Setter for the type.
-    def hsrp_priority=(i); typecast i; end
+    def hsrp_priority=(i); self[:hsrp_priority].read(i); end
     # Getter for the type.
     def hsrp_priority; self[:hsrp_priority].to_i; end
     # Setter for the type.
-    def hsrp_group=(i); typecast i; end
+    def hsrp_group=(i); self[:hsrp_group].read(i); end
     # Getter for the type.
     def hsrp_group; self[:hsrp_group].to_i; end
     # Setter for the type.
-    def hsrp_reserved=(i); typecast i; end
+    def hsrp_reserved=(i); self[:hsrp_reserved].read(i); end
     # Getter for the type.
     def hsrp_reserved; self[:hsrp_reserved].to_i; end
 

--- a/lib/packetfu/protos/icmp/header.rb
+++ b/lib/packetfu/protos/icmp/header.rb
@@ -42,16 +42,16 @@ module PacketFu
     end
 
     # Setter for the type.
-    def icmp_type=(i); typecast i; end
+    def icmp_type=(i); self[:icmp_type].read(i); end
     # Getter for the type.
     def icmp_type; self[:icmp_type].to_i; end
     # Setter for the code.
-    def icmp_code=(i); typecast i; end
+    def icmp_code=(i); self[:icmp_code].read(i); end
     # Getter for the code.
     def icmp_code; self[:icmp_code].to_i; end
     # Setter for the checksum. Note, this is calculated automatically with
     # icmp_calc_sum.
-    def icmp_sum=(i); typecast i; end
+    def icmp_sum=(i); self[:icmp_sum].read(i); end
     # Getter for the checksum.
     def icmp_sum; self[:icmp_sum].to_i; end
 

--- a/lib/packetfu/protos/icmpv6/header.rb
+++ b/lib/packetfu/protos/icmpv6/header.rb
@@ -47,16 +47,16 @@ module PacketFu
     end
 
     # Setter for the type.
-    def icmpv6_type=(i); typecast i; end
+    def icmpv6_type=(i); self[:icmpv6_type].read(i); end
     # Getter for the type.
     def icmpv6_type; self[:icmpv6_type].to_i; end
     # Setter for the code.
-    def icmpv6_code=(i); typecast i; end
+    def icmpv6_code=(i); self[:icmpv6_code].read(i); end
     # Getter for the code.
     def icmpv6_code; self[:icmpv6_code].to_i; end
     # Setter for the checksum. Note, this is calculated automatically with 
     # icmpv6_calc_sum.
-    def icmpv6_sum=(i); typecast i; end
+    def icmpv6_sum=(i); self[:icmpv6_sum].read(i); end
     # Getter for the checksum.
     def icmpv6_sum; self[:icmpv6_sum].to_i; end
 

--- a/lib/packetfu/protos/ip/header.rb
+++ b/lib/packetfu/protos/ip/header.rb
@@ -174,31 +174,31 @@ module PacketFu
     # Getter for the header length (multiply by 4)
     def ip_hl; self[:ip_hl].to_i; end
     # Setter for the differentiated services
-    def ip_tos=(i); typecast i; end
+    def ip_tos=(i); self[:ip_tos].read(i); end
     # Getter for the differentiated services
     def ip_tos; self[:ip_tos].to_i; end
     # Setter for total length.
-    def ip_len=(i); typecast i; end
+    def ip_len=(i); self[:ip_len].read(i); end
     # Getter for total length.
     def ip_len; self[:ip_len].to_i; end
     # Setter for the identication number.
-    def ip_id=(i); typecast i; end
+    def ip_id=(i); self[:ip_id].read(i); end
     # Getter for the identication number.
     def ip_id; self[:ip_id].to_i; end
     # Setter for the fragmentation ID.
-    def ip_frag=(i); typecast i; end
+    def ip_frag=(i); self[:ip_frag].read(i); end
     # Getter for the fragmentation ID.
     def ip_frag; self[:ip_frag].to_i; end
     # Setter for the time to live.
-    def ip_ttl=(i); typecast i; end
+    def ip_ttl=(i); self[:ip_ttl].read(i); end
     # Getter for the time to live.
     def ip_ttl; self[:ip_ttl].to_i; end
     # Setter for the protocol number.
-    def ip_proto=(i); typecast i; end
+    def ip_proto=(i); self[:ip_proto].read(i); end
     # Getter for the protocol number.
     def ip_proto; self[:ip_proto].to_i; end
     # Setter for the checksum.
-    def ip_sum=(i); typecast i; end
+    def ip_sum=(i); self[:ip_sum].read(i); end
     # Getter for the checksum.
     def ip_sum; self[:ip_sum].to_i; end
     # Setter for the source IP address.
@@ -209,7 +209,7 @@ module PacketFu
       when Octets
         self[:ip_src] = i
       else
-        typecast i
+        self[:ip_src].read(i)
       end
     end
     # Getter for the source IP address.
@@ -222,7 +222,7 @@ module PacketFu
       when Octets
         self[:ip_dst] = i
       else
-        typecast i
+        self[:ip_dst].read(i)
       end
     end
     # Getter for the destination IP address.

--- a/lib/packetfu/protos/ipv6/header.rb
+++ b/lib/packetfu/protos/ipv6/header.rb
@@ -129,23 +129,23 @@ module PacketFu
     # Getter for the flow label.
     def ipv6_label; self[:ipv6_label].to_i; end
     # Setter for the payload length.
-    def ipv6_len=(i); typecast i; end
+    def ipv6_len=(i); self[:ipv6_len].read(i); end
     # Getter for the payload length.
     def ipv6_len; self[:ipv6_len].to_i; end
     # Setter for the next protocol header.
-    def ipv6_next=(i); typecast i; end
+    def ipv6_next=(i); self[:ipv6_next].read(i); end
     # Getter for the next protocol header.
     def ipv6_next; self[:ipv6_next].to_i; end
     # Setter for the hop limit.
-    def ipv6_hop=(i); typecast i; end
+    def ipv6_hop=(i); self[:ipv6_hop].read(i); end
     # Getter for the hop limit.
     def ipv6_hop; self[:ipv6_hop].to_i; end
     # Setter for the source address.
-    def ipv6_src=(i); typecast i; end
+    def ipv6_src=(i); self[:ipv6_src].read(i); end
     # Getter for the source address.
     def ipv6_src; self[:ipv6_src].to_i; end
     # Setter for the destination address.
-    def ipv6_dst=(i); typecast i; end
+    def ipv6_dst=(i); self[:ipv6_dst].read(i); end
     # Getter for the destination address.
     def ipv6_dst; self[:ipv6_dst].to_i; end
 

--- a/lib/packetfu/protos/lldp/header.rb
+++ b/lib/packetfu/protos/lldp/header.rb
@@ -118,11 +118,11 @@ module PacketFu
     end
 
     # Setter for the LLDP chassis id type.
-    def lldp_chassis_id_type=(i); typecast i; end
+    def lldp_chassis_id_type=(i); self[:lldp_chassis_id_type].read(i); end
     # Getter for the LLDP chassis id type.
     def lldp_chassis_id_type; self[:lldp_chassis_id_type].to_i; end
     # Setter for the LLDP chassis id.
-    def lldp_chassis_id=(i); typecast i; end
+    def lldp_chassis_id=(i); self[:lldp_chassis_id].read(i); end
     # Getter for the LLDP chassis id .
     def lldp_chassis_id_readable()
       if self[:lldp_chassis_id_type].to_i == 4
@@ -132,11 +132,11 @@ module PacketFu
       end
     end
     # Setter for the LLDP port id type.
-    def lldp_port_id_type=(i); typecast i; end
+    def lldp_port_id_type=(i); self[:lldp_port_id_type].read(i); end
     # Getter for the LLDP port id type.
     def lldp_port_id_type; self[:lldp_port_id_type].to_i; end
     # Setter for the LLDP port id .
-    def lldp_port_id=(i); typecast i; end
+    def lldp_port_id=(i); self[:lldp_port_id].read(i); end
     # Getter for the LLDP port id.
     def lldp_port_id_readable()
       #if mac addr
@@ -156,40 +156,40 @@ module PacketFu
     end
 
     # Setter for the LLDP ttl.
-    def lldp_ttl=(i); typecast i; end
+    def lldp_ttl=(i); self[:lldp_ttl].read(i); end
     # Getter for the LLDP ttl.
     def lldp_ttl; self[:lldp_ttl].to_i; end
     # Setter for the LLDP port description.
-    def lldp_port_description=(i); typecast i; end
+    def lldp_port_description=(i); self[:lldp_port_description].read(i); end
     # Getter for the LLDP port description.
     def lldp_port_description; self[:lldp_port_description].to_s; end
     # Setter for the LLDP system name.
-    def lldp_system_name=(i); typecast i; end
+    def lldp_system_name=(i); self[:lldp_system_name].read(i); end
     # Getter for the LLDP system name.
     def lldp_system_name; self[:lldp_system_name].to_s; end
     # Setter for the LLDP system description.
-    def lldp_system_description=(i); typecast i; end
+    def lldp_system_description=(i); self[:lldp_system_description].read(i); end
     # Getter for the LLDP system description.
     def lldp_system_description; self[:lldp_system_description].to_s; end
     # Setter for the LLDP capability.
-    def lldp_capabilty=(i); typecast i; end
+    def lldp_capabilty=(i); self[:lldp_capabilty].read(i); end
     # Setter for the LLDP enabled capability.
-    def lldp_enabled_capability=(i); typecast i; end
+    def lldp_enabled_capability=(i); self[:lldp_enabled_capability].read(i); end
 
     # Setter for the LLDP address type.
-    def lldp_address_type=(i); typecast i; end
+    def lldp_address_type=(i); self[:lldp_address_type].read(i); end
     # Getter for the LLDP address type.
     def lldp_address_type; self[:lldp_address_type].to_i; end
     # Setter for the LLDP interface type.
-    def lldp_interface_type=(i); typecast i; end
+    def lldp_interface_type=(i); self[:lldp_interface_type].read(i); end
     # Getter for the LLDP interface type.
     def lldp_interface_type; self[:lldp_interface_type].to_i; end
     # Setter for the LLDP interface.
-    def lldp_interface=(i); typecast i; end
+    def lldp_interface=(i); self[:lldp_interface].read(i); end
     # Getter for the LLDP interface type.
     def lldp_interface; self[:lldp_interface].to_i; end
     # Setter for the LLDP oid.
-    def lldp_oid=(i); typecast i; end
+    def lldp_oid=(i); self[:lldp_oid].read(i); end
     # Getter for the LLDP oid type.
     def lldp_oid; self[:lldp_oid].to_i; end
 

--- a/lib/packetfu/protos/tcp/header.rb
+++ b/lib/packetfu/protos/tcp/header.rb
@@ -111,31 +111,31 @@ module PacketFu
     end
 
     # Setter for the TCP source port.
-    def tcp_src=(i); typecast i; end
+    def tcp_src=(i); self[:tcp_src].read(i); end
     # Getter for the TCP source port.
     def tcp_src; self[:tcp_src].to_i; end
     # Setter for the TCP destination port.
-    def tcp_dst=(i); typecast i; end
+    def tcp_dst=(i); self[:tcp_dst].read(i); end
     # Getter for the TCP destination port.
     def tcp_dst; self[:tcp_dst].to_i; end
     # Setter for the TCP sequence number.
-    def tcp_seq=(i); typecast i; end
+    def tcp_seq=(i); self[:tcp_seq].read(i); end
     # Getter for the TCP sequence number.
     def tcp_seq; self[:tcp_seq].to_i; end
     # Setter for the TCP ackowlegement number.
-    def tcp_ack=(i); typecast i; end
+    def tcp_ack=(i); self[:tcp_ack].read(i); end
     # Getter for the TCP ackowlegement number.
     def tcp_ack; self[:tcp_ack].to_i; end
     # Setter for the TCP window size number.
-    def tcp_win=(i); typecast i; end
+    def tcp_win=(i); self[:tcp_win].read(i); end
     # Getter for the TCP window size number.
     def tcp_win; self[:tcp_win].to_i; end
     # Setter for the TCP checksum.
-    def tcp_sum=(i); typecast i; end
+    def tcp_sum=(i); self[:tcp_sum].read(i); end
     # Getter for the TCP checksum.
     def tcp_sum; self[:tcp_sum].to_i; end
     # Setter for the TCP urgent field.
-    def tcp_urg=(i); typecast i; end
+    def tcp_urg=(i); self[:tcp_urg].read(i); end
     # Getter for the TCP urgent field.
     def tcp_urg; self[:tcp_urg].to_i; end
 

--- a/lib/packetfu/protos/tcp/option.rb
+++ b/lib/packetfu/protos/tcp/option.rb
@@ -6,7 +6,7 @@ module PacketFu
   #
   # Subclassed options should set the correct TcpOption#kind by redefining 
   # initialize. They should also deal with various value types there by setting
-  # them explicitly with an accompanying StructFu#typecast for the setter. 
+  # them explicitly with an accompanying .read() call for the setter.
   #
   # By default, values are presumed to be strings, unless they are Numeric, in
   # which case a guess is made to the width of the Numeric based on the given
@@ -63,14 +63,14 @@ module PacketFu
     end
 
     # Setter for the "kind" byte of this option.
-    def kind=(i); typecast i; end
+    def kind=(i); self[:kind].read(i); end
     # Setter for the "option length" byte for this option.
-    def optlen=(i); typecast i; end
+    def optlen=(i); self[:optlen].read(i); end
 
     # Setter for the value of this option. 
     def value=(i)
       if i.kind_of? Numeric
-        typecast i
+        self[:value].read(i)
       elsif i.respond_to? :to_s
         self[:value] = i
       else
@@ -140,7 +140,7 @@ module PacketFu
         self[:value] = Int16.new(args[:value])
       end
 
-      def value=(i); typecast i; end
+      def value=(i); self[:value].read(i); end
 
       # MSS options with lengths other than 4 are malformed.
       def decode
@@ -166,7 +166,7 @@ module PacketFu
         self[:value] = Int8.new(args[:value])
       end
 
-      def value=(i); typecast i; end
+      def value=(i); self[:value].read(i); end
 
       # WS options with lengths other than 3 are malformed.
       def decode
@@ -215,7 +215,7 @@ module PacketFu
         )
       end
 
-      def optlen=(i); typecast i; end
+      def optlen=(i); self[:optlen].read(i); end
 
       def value=(i)
         self[:optlen] = Int8.new(i.to_s.size + 2)

--- a/lib/packetfu/protos/udp/header.rb
+++ b/lib/packetfu/protos/udp/header.rb
@@ -44,19 +44,19 @@ module PacketFu
     end
 
     # Setter for the UDP source port.
-    def udp_src=(i); typecast i; end
+    def udp_src=(i); self[:udp_src].read(i); end
     # Getter for the UDP source port.
     def udp_src; self[:udp_src].to_i; end
     # Setter for the UDP destination port.
-    def udp_dst=(i); typecast i; end
+    def udp_dst=(i); self[:udp_dst].read(i); end
     # Getter for the UDP destination port.
     def udp_dst; self[:udp_dst].to_i; end
     # Setter for the length field. Usually should be recalc()'ed instead.
-    def udp_len=(i); typecast i; end
+    def udp_len=(i); self[:udp_len].read(i); end
     # Getter for the length field.
     def udp_len; self[:udp_len].to_i; end
     # Setter for the checksum. Usually should be recalc()'ed instad.
-    def udp_sum=(i); typecast i; end
+    def udp_sum=(i); self[:udp_sum].read(i); end
     # Getter for the checksum.
     def udp_sum; self[:udp_sum].to_i; end
 

--- a/lib/packetfu/structfu.rb
+++ b/lib/packetfu/structfu.rb
@@ -13,18 +13,10 @@ module StructFu
 
   alias len sz
 
-  # Typecast is used mostly by packet header classes, such as IPHeader,
-  # TCPHeader, and the like. It takes an argument, and casts it to the
-  # expected type for that element.
-  def typecast(i)
-    c = caller[0].match(/.*`([^']+)='/)[1]
-    self[c.to_sym].read i
-  end
-
-  # Used like typecast(), but specifically for casting Strings to StructFu::Strings.
+  # Helper for casting Strings to StructFu::Strings.
   def body=(i)
     if i.kind_of? ::String
-      typecast(i)
+      self[:body].read(i)
     elsif i.kind_of? StructFu
       self[:body] = i
     elsif i.nil?

--- a/spec/structfu_spec.rb
+++ b/spec/structfu_spec.rb
@@ -11,7 +11,6 @@ describe StructFu, "mixin methods" do
   it "should provide the basic StructFu methods" do
     expect(@sc).to respond_to(:sz)
     expect(@sc).to respond_to(:len)
-    expect(@sc).to respond_to(:typecast)
     expect(@sc).to respond_to(:body=)
   end
 end

--- a/spec/structfu_spec.rb
+++ b/spec/structfu_spec.rb
@@ -144,8 +144,8 @@ describe StructFu::Int16le, "2 byte little-endian value" do
   end
 
   it "should raise when you try to change endianness" do
-    expect { @int.endian = :big }.to raise_error(NoMethodError, /undefined method `endian='/)
-    expect { @int.endian = :little }.to raise_error(NoMethodError, /undefined method `endian='/)
+    expect { @int.endian = :big }.to raise_error(NoMethodError, /undefined method .endian=/)
+    expect { @int.endian = :little }.to raise_error(NoMethodError, /undefined method .endian=/)
   end
 
 end
@@ -161,8 +161,8 @@ describe StructFu::Int16be, "2 byte big-endian value" do
   end
 
   it "should raise when you try to change endianness" do
-    expect { @int.endian = :big }.to raise_error(NoMethodError, /undefined method `endian='/)
-    expect { @int.endian = :little }.to raise_error(NoMethodError, /undefined method `endian='/)
+    expect { @int.endian = :big }.to raise_error(NoMethodError, /undefined method .endian=/)
+    expect { @int.endian = :little }.to raise_error(NoMethodError, /undefined method .endian=/)
   end
 
 end
@@ -233,8 +233,8 @@ describe StructFu::Int32le, "4 byte little-endian value" do
   end
 
   it "should raise when you try to change endianness" do
-    expect { @int.endian = :big }.to raise_error(NoMethodError, /undefined method `endian='/)
-    expect { @int.endian = :little }.to raise_error(NoMethodError, /undefined method `endian='/)
+    expect { @int.endian = :big }.to raise_error(NoMethodError, /undefined method .endian=/)
+    expect { @int.endian = :little }.to raise_error(NoMethodError, /undefined method .endian=/)
   end
 
 end
@@ -250,8 +250,8 @@ describe StructFu::Int32be, "4 byte big-endian value" do
   end
 
   it "should raise when you try to change endianness" do
-    expect { @int.endian = :big }.to raise_error(NoMethodError, /undefined method `endian='/)
-    expect { @int.endian = :little }.to raise_error(NoMethodError, /undefined method `endian='/)
+    expect { @int.endian = :big }.to raise_error(NoMethodError, /undefined method .endian=/)
+    expect { @int.endian = :little }.to raise_error(NoMethodError, /undefined method .endian=/)
   end
 
 end


### PR DESCRIPTION
In the [the release notes for Ruby 3.4](https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/):

- Error messages and backtrace displays have been changed.
  - Use a single quote instead of a backtick as a opening quote. [[Feature #16495](https://bugs.ruby-lang.org/issues/16495)]
  - Display a class name before a method name (only when the class has a permanent name). [[Feature #19117](https://bugs.ruby-lang.org/issues/19117)]
  - Kernel#caller, Thread::Backtrace::Location’s methods, etc. are also changed accordingly.

This causes the `StructFu#typecast` helper to fail as it performs a regex on the stack to determine the attribute being set: https://github.com/packetfu/packetfu/blob/0c1f524fd1aa0715df0caa014b45be93812b4bf1/lib/packetfu/structfu.rb#L19-L22

Rather than fix the regex, I removed the `.typecast` helper as, in my opinion, regexing the stack to determine which attribute the caller is operating on to be a code smell.  The getters simply perform `self[:attr].method`, so I unrolled `typecast` to perform `self[:attr].read` in it's place.  This should be backwards compatible and more performant.

Additionally I updated the exception regexes in the StructFu spec to pass on Ruby 3.4.  This is also backwards compatible.

Resolves #217 