### PR TITLE
Fix parsing out the ethernet address

### DIFF
--- a/lib/packetfu/utils.rb
+++ b/lib/packetfu/utils.rb
@@ -253,12 +253,12 @@ module PacketFu
           case s
           when /ether\s+(([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2})/
             ret[:eth_saddr] = $1.downcase
-          when /inet addr:[\s]*([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(.*Mask:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+))?/i
+          when /inet (?:addr:)?[\s]*([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(\s+(?:Mask:|netmask\s+)([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+))?/i
             ret[:ip_saddr] = $1
             ret[:ip_src] = [IPAddr.new($1).to_i].pack("N")
             ret[:ip4_obj] = IPAddr.new($1)
             ret[:ip4_obj] = ret[:ip4_obj].mask($3) if $3
-          when /inet6 addr:[\s]*([0-9a-fA-F:\x2f]+)/
+          when /inet6 (?:addr:)?[\s]*([0-9a-fA-F:\x2f]+)/
             ret[:ip6_saddr] = $1
             ret[:ip6_obj] = IPAddr.new($1)
           end


### PR DESCRIPTION
This fixes issue #206 which I ran into while testing  rapid7/metasploit-framework#20128. The issue seems to be due to the change in `ifconfig`'s output where the ethernet address is now a line prefixed with `ether`.

For reference, this is my ifconfig version and output:
```
 : packetfu:fix/issue/20616:45:14 fedora-vm packetfu ifconfig --version
net-tools 2.10-alpha
  : packetfu:fix/issue/20616:45:17 fedora-vm packetfu ifconfig
ens33: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.250.134  netmask 255.255.255.0  broadcast 192.168.250.255
        inet6 fe80::31fd:3fdd:e78b:ea63  prefixlen 64  scopeid 0x20<link>
        ether 00:0c:29:37:a1:b8  txqueuelen 1000  (Ethernet)
        RX packets 416848  bytes 395370052 (377.0 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 193456  bytes 38101018 (36.3 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

ens37: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.159.128  netmask 255.255.255.0  broadcast 192.168.159.255
        inet6 fe80::4fb:d69d:68ac:3fe9  prefixlen 64  scopeid 0x20<link>
        ether 00:0c:29:37:a1:c2  txqueuelen 1000  (Ethernet)
        RX packets 1938  bytes 205589 (200.7 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 12270  bytes 885420 (864.6 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

ens160: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.56.128  netmask 255.255.255.0  broadcast 192.168.56.255
        inet6 fe80::d9ac:cb7d:e8ee:420b  prefixlen 64  scopeid 0x20<link>
        ether 00:0c:29:37:a1:cc  txqueuelen 1000  (Ethernet)
        RX packets 1450  bytes 138716 (135.4 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 996  bytes 198665 (194.0 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
        inet 127.0.0.1  netmask 255.0.0.0
        inet6 ::1  prefixlen 128  scopeid 0x10<host>
        loop  txqueuelen 1000  (Local Loopback)
        RX packets 295301  bytes 533088793 (508.3 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 295301  bytes 533088793 (508.3 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```